### PR TITLE
Simplify clients

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -23,7 +23,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -r dev-requirements.txt
       - name: Run tests
-        run: pytest -m "not livetest and not tmpdir" --cov=file_retriever/
+        run: pytest -m "not livetest" --cov=file_retriever/
       - name: Send report to Coveralls
         uses: AndreMiras/coveralls-python-action@develop
         with:

--- a/file_retriever/connect.py
+++ b/file_retriever/connect.py
@@ -38,23 +38,23 @@ class Client:
 
         self.vendor = vendor
         self.host = host
-        self.port = int(port)
+        self.port = port
         self.remote_dir = remote_dir
 
-        self.session = self._create_client(username=username, password=password)
+        self.session = self.__create_client(username=username, password=password)
 
-    def _create_client(
+    def __create_client(
         self, username: str, password: str
     ) -> Union[_ftpClient, _sftpClient]:
         match self.port:
-            case 21:
+            case 21 | "21":
                 return _ftpClient(
                     username=username,
                     password=password,
                     host=self.host,
                     port=self.port,
                 )
-            case 22:
+            case 22 | "22":
                 return _sftpClient(
                     username=username,
                     password=password,
@@ -84,24 +84,24 @@ class Client:
             else:
                 return os.path.exists(os.path.join(check_dir, file))
 
-    def get_file_data(self, file: str, remote_dir: Optional[str] = None) -> List[File]:
+    def get_file_data(self, file: str, remote_dir: Optional[str] = None) -> File:
         """
-        Retrieve metadata for file in `remote_dir` on server. If `remote_dir` is not
-        provided then data for file in `self.remote_dir` will be retrieved.
+        Retrieve metadata for `file` in `remote_dir` on server. If `remote_dir` is not
+        provided then data for `file` in `self.remote_dir` will be retrieved.
 
         Args:
             file: name of file to retrieve metadata for
             remote_dir: directory on server to interact with
 
         Returns:
-            files in `remote_dir` represented as `File` object
+            file in `remote_dir` represented as `File` object
         """
         if not remote_dir or remote_dir is None:
             remote_dir = self.remote_dir
         with self.session as session:
             return session.get_remote_file_data(file, remote_dir)
 
-    def list_files(
+    def list_files_in_dir(
         self, time_delta: int = 0, remote_dir: Optional[str] = None
     ) -> List[File]:
         """

--- a/file_retriever/connect.py
+++ b/file_retriever/connect.py
@@ -122,7 +122,7 @@ class Client:
         if not remote_dir or remote_dir is None:
             remote_dir = self.remote_dir
         with self.session as session:
-            files = session.list_file_data(remote_dir)
+            files = session.list_remote_file_data(remote_dir)
             if time_delta > 0:
                 return [
                     i

--- a/file_retriever/connect.py
+++ b/file_retriever/connect.py
@@ -41,9 +41,9 @@ class Client:
         self.port = port
         self.remote_dir = remote_dir
 
-        self.session = self.__create_client(username=username, password=password)
+        self.session = self.__connect_to_server(username=username, password=password)
 
-    def __create_client(
+    def __connect_to_server(
         self, username: str, password: str
     ) -> Union[_ftpClient, _sftpClient]:
         match self.port:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ pytest-mock = "^3.14.0"
 testpaths = ["tests"]
 markers = [
     "livetest: mark a test as hitting a live ftp/sftp server",
-    "tmpdir: mark a test as using a temporary directory",
 ]
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,15 +51,6 @@ class Mock_SFTPAttributes(paramiko.SFTPAttributes):
 class MockFTP:
     """Mock response from FTP server for a successful login"""
 
-    def __init__(self, *args, **kwargs):
-        pass
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *args) -> None:
-        self.close()
-
     def close(self, *args, **kwargs) -> None:
         pass
 
@@ -89,15 +80,6 @@ class MockFTP:
 class MockSFTPClient:
     """Mock response from SFTP for a successful login"""
 
-    def __init__(self):
-        pass
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *args) -> None:
-        self.close()
-
     def close(self, *args, **kwargs) -> None:
         pass
 
@@ -112,22 +94,6 @@ class MockSFTPClient:
 
     def stat(self, *args, **kwargs) -> paramiko.SFTPAttributes:
         return Mock_SFTPAttributes()
-
-
-class MockSSHClient:
-    """Mock response from SSH for a successful login"""
-
-    def __init__(self):
-        pass
-
-    def connect(self, *args, **kwargs) -> None:
-        pass
-
-    def open_sftp(self, *args, **kwargs) -> MockSFTPClient:
-        return MockSFTPClient()
-
-    def set_missing_host_key_policy(self, *args, **kwargs) -> None:
-        pass
 
 
 @pytest.fixture
@@ -168,8 +134,8 @@ def stub_client(monkeypatch, mock_open_file, mock_client):
     def mock_file_not_found(*args, **kwargs):
         return False
 
-    monkeypatch.setattr(_ftpClient, "_create_ftp_connection", mock_ftp_client)
-    monkeypatch.setattr(_sftpClient, "_create_sftp_connection", mock_sftp_client)
+    monkeypatch.setattr(_ftpClient, "_connect_to_server", mock_ftp_client)
+    monkeypatch.setattr(_sftpClient, "_connect_to_server", mock_sftp_client)
     monkeypatch.setattr(Client, "check_file", mock_file_not_found)
 
 
@@ -181,8 +147,8 @@ def stub_client_tmp_path(monkeypatch, mock_client):
     def mock_sftp_client(*args, **kwargs):
         return MockSFTPClient()
 
-    monkeypatch.setattr(_ftpClient, "_create_ftp_connection", mock_ftp_client)
-    monkeypatch.setattr(_sftpClient, "_create_sftp_connection", mock_sftp_client)
+    monkeypatch.setattr(_ftpClient, "_connect_to_server", mock_ftp_client)
+    monkeypatch.setattr(_sftpClient, "_connect_to_server", mock_sftp_client)
 
 
 @pytest.fixture
@@ -202,10 +168,8 @@ def stub_client_file_exists(monkeypatch, mock_open_file, mock_client):
         return True
 
     monkeypatch.setattr(os.path, "exists", path_exists)
-    monkeypatch.setattr(_ftpClient, "_create_ftp_connection", mock_ftp_client)
-    monkeypatch.setattr(_sftpClient, "_create_sftp_connection", mock_sftp_client)
-    # monkeypatch.setattr(_ftpClient, "get_remote_file_data", mock_file_exists)
-    # monkeypatch.setattr(_sftpClient, "get_remote_file_data", mock_file_exists)
+    monkeypatch.setattr(_ftpClient, "_connect_to_server", mock_ftp_client)
+    monkeypatch.setattr(_sftpClient, "_connect_to_server", mock_sftp_client)
 
 
 class MockOSError:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ import paramiko
 from typing import Dict, List
 import yaml
 import pytest
-from file_retriever._clients import _ftpClient, _sftpClient
+from file_retriever._clients import _ftpClient, _sftpClient, _BaseClient
 from file_retriever.connect import Client
 
 
@@ -92,6 +92,21 @@ class MockSFTPClient:
 
     def stat(self, *args, **kwargs) -> paramiko.SFTPAttributes:
         return MockFileData().create_SFTPAttributes()
+
+
+class MockABCClient:
+    """Mock response from SFTP for a successful login"""
+
+    def close(self, *args, **kwargs) -> None:
+        pass
+
+
+@pytest.fixture
+def mock_BaseClient(monkeypatch):
+    def mock_bc(*args, **kwargs):
+        return MockABCClient()
+
+    monkeypatch.setattr(_BaseClient, "_connect_to_server", mock_bc)
 
 
 @pytest.fixture

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -42,7 +42,9 @@ class TestMock_ftpClient:
         with pytest.raises(ftplib.error_temp):
             _ftpClient(**stub_creds)
 
-    def test_ftpClient_get_remote_file_data(self, stub_client, stub_creds):
+    def test_ftpClient_get_remote_file_data(
+        self, mock_ftpClient_sftpClient, stub_creds
+    ):
         stub_creds["port"] = "21"
         ftp = _ftpClient(**stub_creds)
         files = ftp.get_remote_file_data("foo.mrc", "testdir")
@@ -80,7 +82,9 @@ class TestMock_ftpClient:
         with pytest.raises(ftplib.error_perm):
             ftp.get_remote_file_data("foo.mrc", "testdir")
 
-    def test_ftpClient_list_remote_file_data(self, stub_client, stub_creds):
+    def test_ftpClient_list_remote_file_data(
+        self, mock_ftpClient_sftpClient, stub_creds
+    ):
         stub_creds["port"] = "21"
         ftp = _ftpClient(**stub_creds)
         files = ftp.list_remote_file_data("testdir")
@@ -104,7 +108,7 @@ class TestMock_ftpClient:
         with pytest.raises(ftplib.error_reply):
             ftp.list_remote_file_data("testdir")
 
-    def test_ftpClient_download_file(self, stub_client, stub_creds):
+    def test_ftpClient_download_file(self, mock_ftpClient_sftpClient, stub_creds):
         stub_creds["port"] = "21"
         with does_not_raise():
             ftp = _ftpClient(**stub_creds)
@@ -124,7 +128,7 @@ class TestMock_ftpClient:
             ftp = _ftpClient(**stub_creds)
             ftp.download_file(file="foo.mrc", remote_dir="bar", local_dir="test")
 
-    def test_ftpClient_upload_file(self, stub_client, stub_creds):
+    def test_ftpClient_upload_file(self, mock_ftpClient_sftpClient, stub_creds):
         stub_creds["port"] = "21"
         ftp = _ftpClient(**stub_creds)
         file = ftp.upload_file(file="foo.mrc", local_dir="foo", remote_dir="bar")
@@ -148,18 +152,18 @@ class TestMock_ftpClient:
 class TestMock_sftpClient:
     """Test the _sftpClient class with mock responses."""
 
-    def test_sftpClient(self, mock_client, stub_creds):
+    def test_sftpClient(self, stub_client, stub_creds):
         stub_creds["port"] = "22"
         sftp = _sftpClient(**stub_creds)
         assert sftp.connection is not None
 
     @pytest.mark.parametrize("port", [None, [], {}])
-    def test_sftpClient_port_ValueError(self, mock_client, stub_creds, port):
+    def test_sftpClient_port_ValueError(self, stub_client, stub_creds, port):
         stub_creds["port"] = port
         with pytest.raises(ValueError):
             _sftpClient(**stub_creds)
 
-    def test_sftpClient_no_creds(self, mock_client):
+    def test_sftpClient_no_creds(self, stub_client):
         creds = {}
         with pytest.raises(TypeError):
             _sftpClient(**creds)
@@ -174,12 +178,14 @@ class TestMock_sftpClient:
         with pytest.raises(paramiko.SSHException):
             _sftpClient(**stub_creds)
 
-    def test_sftpClient_context_manager(self, mock_client, stub_creds):
+    def test_sftpClient_context_manager(self, stub_client, stub_creds):
         stub_creds["port"] = "22"
         with _sftpClient(**stub_creds) as client:
             assert client.connection is not None
 
-    def test_sftpClient_get_remote_file_data(self, stub_client, stub_creds):
+    def test_sftpClient_get_remote_file_data(
+        self, mock_ftpClient_sftpClient, stub_creds
+    ):
         stub_creds["port"] = "22"
         ftp = _sftpClient(**stub_creds)
         file = ftp.get_remote_file_data("foo.mrc", "testdir")
@@ -201,7 +207,9 @@ class TestMock_sftpClient:
         with pytest.raises(OSError):
             sftp.get_remote_file_data("foo.mrc", "testdir")
 
-    def test_sftpClient_list_remote_file_data(self, stub_client, stub_creds):
+    def test_sftpClient_list_remote_file_data(
+        self, mock_ftpClient_sftpClient, stub_creds
+    ):
         stub_creds["port"] = "22"
         ftp = _sftpClient(**stub_creds)
         files = ftp.list_remote_file_data("testdir")
@@ -225,7 +233,7 @@ class TestMock_sftpClient:
         with pytest.raises(OSError):
             sftp.list_remote_file_data("testdir")
 
-    def test_sftpClient_download_file(self, stub_client, stub_creds):
+    def test_sftpClient_download_file(self, mock_ftpClient_sftpClient, stub_creds):
         stub_creds["port"] = "22"
         with does_not_raise():
             sftp = _sftpClient(**stub_creds)
@@ -237,7 +245,7 @@ class TestMock_sftpClient:
         with pytest.raises(OSError):
             sftp.download_file(file="foo.mrc", remote_dir="bar", local_dir="test")
 
-    def test_sftpClient_upload_file(self, stub_client, stub_creds):
+    def test_sftpClient_upload_file(self, mock_ftpClient_sftpClient, stub_creds):
         stub_creds["port"] = "22"
         sftp = _sftpClient(**stub_creds)
         file = sftp.upload_file(file="foo.mrc", local_dir="foo", remote_dir="bar")

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -4,8 +4,28 @@ import ftplib
 import os
 import paramiko
 import pytest
-from file_retriever._clients import _ftpClient, _sftpClient
+from file_retriever._clients import _ftpClient, _sftpClient, _BaseClient
 from file_retriever.file import File
+
+
+def test_BaseClient():
+    _BaseClient.__abstractmethods__ = set()
+    ftp_bc = _BaseClient(username="foo", password="bar", host="baz", port=21)
+    assert ftp_bc.__dict__ == {"connection": None}
+    assert ftp_bc.get_remote_file_data("foo.mrc", "bar") is None
+    assert ftp_bc.list_remote_file_data("foo") is None
+    assert ftp_bc.download_file("foo.mrc", "bar", "baz") is None
+    assert ftp_bc.upload_file("foo.mrc", "bar", "baz") is None
+
+
+def test_BaseClient_context_manager(mock_BaseClient):
+    _BaseClient.__abstractmethods__ = set()
+    with _BaseClient(username="foo", password="bar", host="baz", port=22) as sftp_bc:
+        assert sftp_bc.connection is not None
+        assert sftp_bc.get_remote_file_data("foo.mrc", "bar") is None
+        assert sftp_bc.list_remote_file_data("foo") is None
+        assert sftp_bc.download_file("foo.mrc", "bar", "baz") is None
+        assert sftp_bc.upload_file("foo.mrc", "bar", "baz") is None
 
 
 class TestMock_ftpClient:

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -104,16 +104,7 @@ class TestMock_ftpClient:
         with pytest.raises(ftplib.error_reply):
             ftp.list_file_data("testdir")
 
-    @pytest.mark.tmpdir
-    def test_ftpClient_download_file(self, tmp_path, stub_client_tmp_path, stub_creds):
-        stub_creds["port"] = "21"
-        path = tmp_path / "test"
-        path.mkdir()
-        ftp = _ftpClient(**stub_creds)
-        ftp.download_file(file="foo.mrc", remote_dir="bar", local_dir=str(path))
-        assert "foo.mrc" in os.listdir(path)
-
-    def test_ftpClient_download_mock_file(self, stub_client, stub_creds):
+    def test_ftpClient_download_file(self, stub_client, stub_creds):
         stub_creds["port"] = "21"
         with does_not_raise():
             ftp = _ftpClient(**stub_creds)
@@ -232,16 +223,7 @@ class TestMock_sftpClient:
         with pytest.raises(OSError):
             sftp.list_file_data("testdir")
 
-    @pytest.mark.tmpdir
-    def test_sftpClient_download_file(self, tmp_path, stub_client_tmp_path, stub_creds):
-        stub_creds["port"] = "22"
-        path = tmp_path / "test"
-        path.mkdir()
-        sftp = _sftpClient(**stub_creds)
-        sftp.download_file(file="foo.mrc", remote_dir="bar", local_dir=str(path))
-        assert "foo.mrc" in os.listdir(path)
-
-    def test_sftpClient_download_mock_file(self, stub_client, stub_creds):
+    def test_sftpClient_download_file(self, stub_client, stub_creds):
         stub_creds["port"] = "22"
         with does_not_raise():
             sftp = _sftpClient(**stub_creds)

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -20,7 +20,7 @@ class TestMockClient:
             ),
         ],
     )
-    def test_Client(self, stub_client, stub_creds, port, client_type):
+    def test_Client(self, mock_Client, stub_creds, port, client_type):
         (
             stub_creds["port"],
             stub_creds["remote_dir"],
@@ -33,7 +33,7 @@ class TestMockClient:
         assert connect.remote_dir == "testdir"
         assert isinstance(connect.session, client_type)
 
-    def test_Client_invalid_port(self, stub_client, stub_creds):
+    def test_Client_invalid_port(self, mock_Client, stub_creds):
         (
             stub_creds["port"],
             stub_creds["remote_dir"],
@@ -65,7 +65,7 @@ class TestMockClient:
         "port",
         [21, 22],
     )
-    def test_Client_check_file_local(self, stub_client_file_exists, stub_creds, port):
+    def test_Client_check_file_local(self, mock_Client_file_exists, stub_creds, port):
         (
             stub_creds["port"],
             stub_creds["remote_dir"],
@@ -79,7 +79,7 @@ class TestMockClient:
         "port",
         [21, 22],
     )
-    def test_Client_check_file_remote(self, stub_client_file_exists, stub_creds, port):
+    def test_Client_check_file_remote(self, mock_Client_file_exists, stub_creds, port):
         (
             stub_creds["port"],
             stub_creds["remote_dir"],
@@ -93,7 +93,7 @@ class TestMockClient:
         "port, dir, uid_gid",
         [(21, "testdir", None), (21, None, None), (22, "testdir", 0), (22, None, 0)],
     )
-    def test_Client_get_file_data(self, stub_client, stub_creds, port, dir, uid_gid):
+    def test_Client_get_file_data(self, mock_Client, stub_creds, port, dir, uid_gid):
         (
             stub_creds["port"],
             stub_creds["remote_dir"],
@@ -134,7 +134,7 @@ class TestMockClient:
             connect.get_file_data("foo.mrc", "testdir")
 
     @pytest.mark.parametrize("port, uid_gid", [(21, None), (22, 0)])
-    def test_Client_list_files_in_dir(self, stub_client, stub_creds, port, uid_gid):
+    def test_Client_list_files_in_dir(self, mock_Client, stub_creds, port, uid_gid):
         (
             stub_creds["port"],
             stub_creds["remote_dir"],
@@ -182,7 +182,7 @@ class TestMockClient:
         "port, dir",
         [(21, "testdir"), (21, None), (22, "testdir"), (22, None)],
     )
-    def test_Client_get_file(self, stub_client, stub_creds, port, dir):
+    def test_Client_get_file(self, mock_Client, stub_creds, port, dir):
         (
             stub_creds["port"],
             stub_creds["remote_dir"],
@@ -220,7 +220,7 @@ class TestMockClient:
         [21, 22],
     )
     def test_Client_get_check_file_exists_true(
-        self, stub_client_file_exists, stub_creds, port
+        self, mock_Client_file_exists, stub_creds, port
     ):
         (
             stub_creds["port"],
@@ -236,7 +236,7 @@ class TestMockClient:
         [(21, "testdir"), (21, None), (22, "testdir"), (22, None)],
     )
     def test_Client_get_check_file_exists_false(
-        self, stub_client, stub_creds, port, dir
+        self, mock_Client, stub_creds, port, dir
     ):
         (
             stub_creds["port"],
@@ -261,7 +261,7 @@ class TestMockClient:
         "port, dir, uid_gid",
         [(21, None, None), (21, "test", None), (22, None, 0), (22, "test", 0)],
     )
-    def test_Client_put_file(self, stub_client, stub_creds, port, dir, uid_gid):
+    def test_Client_put_file(self, mock_Client, stub_creds, port, dir, uid_gid):
         (
             stub_creds["port"],
             stub_creds["remote_dir"],
@@ -313,7 +313,7 @@ class TestMockClient:
         [21, 22],
     )
     def test_Client_put_check_file_exists_true(
-        self, stub_client_file_exists, stub_creds, port
+        self, mock_Client_file_exists, stub_creds, port
     ):
         (
             stub_creds["port"],
@@ -331,7 +331,7 @@ class TestMockClient:
         [(21, None), (22, 0)],
     )
     def test_Client_put_check_file_exists_false(
-        self, stub_client, stub_creds, port, uid_gid
+        self, mock_Client, stub_creds, port, uid_gid
     ):
         (
             stub_creds["port"],

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -134,15 +134,15 @@ class TestMockClient:
             connect.get_file_data("foo.mrc", "testdir")
 
     @pytest.mark.parametrize("port, uid_gid", [(21, None), (22, 0)])
-    def test_Client_list_files(self, stub_client, stub_creds, port, uid_gid):
+    def test_Client_list_files_in_dir(self, stub_client, stub_creds, port, uid_gid):
         (
             stub_creds["port"],
             stub_creds["remote_dir"],
             stub_creds["vendor"],
         ) = (port, "testdir", "test")
         connect = Client(**stub_creds)
-        all_files = connect.list_files()
-        recent_files = connect.list_files(time_delta=5, remote_dir="testdir")
+        all_files = connect.list_files_in_dir()
+        recent_files = connect.list_files_in_dir(time_delta=5, remote_dir="testdir")
         assert all_files == [
             File(
                 file_name="foo.mrc",
@@ -166,7 +166,7 @@ class TestMockClient:
         ) = (21, "testdir", "test")
         connect = Client(**stub_creds)
         with pytest.raises(ftplib.error_reply):
-            connect.list_files()
+            connect.list_files_in_dir()
 
     def test_Client_list_sftp_file_not_found(self, mock_file_error, stub_creds):
         (
@@ -176,7 +176,7 @@ class TestMockClient:
         ) = (22, "testdir", "test")
         connect = Client(**stub_creds)
         with pytest.raises(OSError):
-            connect.list_files()
+            connect.list_files_in_dir()
 
     @pytest.mark.parametrize(
         "port, dir",
@@ -356,7 +356,7 @@ class TestMockClient:
 @pytest.mark.livetest
 def test_Client_ftp_live_test(live_ftp_creds):
     live_ftp = Client(**live_ftp_creds)
-    files = live_ftp.list_files()
+    files = live_ftp.list_files_in_dir()
     assert len(files) > 1
     assert "220" in live_ftp.session.connection.getwelcome()
 
@@ -364,6 +364,6 @@ def test_Client_ftp_live_test(live_ftp_creds):
 @pytest.mark.livetest
 def test_Client_sftp_live_test(live_sftp_creds):
     live_sftp = Client(**live_sftp_creds)
-    files = live_sftp.list_files()
+    files = live_sftp.list_files_in_dir()
     assert len(files) > 1
     assert live_sftp.session.connection.get_channel().active == 1


### PR DESCRIPTION
Added:
 + `_BaseClient` abstract base class which _ftpClient and _sftpClient now inherit from
 + tests

Removed:
 + `tmp_path` tests

Changed:
 + renamed `_create_ftp_connection` and `_create_sftp_connection` to `_connect_to_server`
 + renamed `list_file_data` to `list_remote_file_data`
 + `Client._create_client` is now a private method (`__connect_to_server`)
 + clarified `port` variable. it is now converted to an int during initialization of `_ftpClient` and `_sftpClient`
 + renamed `Client.list_files` to `Client_list_files_in_dir`

Fixed:
 + typo in `Client.get_file_data` return value (`List[File]` is now `File`)