### PR TITLE
Added logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,4 @@ config.yaml
 creds.yaml
 temp/*
 *.mrc
+run.py

--- a/file_retriever/utils.py
+++ b/file_retriever/utils.py
@@ -1,16 +1,13 @@
-from collections import Counter
 import os
 import yaml
 
 
-def vendor_config(config_path: str):
-    vendors = []
+def vendor_config(config_path: str) -> None:
+    """Set environment variables from config file"""
     with open(config_path, "r") as file:
         config = yaml.safe_load(file)
         for k, v in config.items():
             os.environ[k] = v
-            vendors.append(f"{k.split('_')[0]}")
-    print(*Counter(vendors))
 
 
 def logger_config() -> dict:

--- a/file_retriever/utils.py
+++ b/file_retriever/utils.py
@@ -2,14 +2,6 @@ import os
 import yaml
 
 
-def vendor_config(config_path: str) -> None:
-    """Set environment variables from config file"""
-    with open(config_path, "r") as file:
-        config = yaml.safe_load(file)
-        for k, v in config.items():
-            os.environ[k] = v
-
-
 def logger_config() -> dict:
     """Create dict for logger configuration"""
     log_config_dict = {
@@ -36,3 +28,11 @@ def logger_config() -> dict:
         },
     }
     return log_config_dict
+
+
+def vendor_config(config_path: str) -> None:
+    """Set environment variables from config file"""
+    with open(config_path, "r") as file:
+        config = yaml.safe_load(file)
+        for k, v in config.items():
+            os.environ[k] = v

--- a/file_retriever/utils.py
+++ b/file_retriever/utils.py
@@ -1,0 +1,41 @@
+from collections import Counter
+import os
+import yaml
+
+
+def vendor_config(config_path: str):
+    vendors = []
+    with open(config_path, "r") as file:
+        config = yaml.safe_load(file)
+        for k, v in config.items():
+            os.environ[k] = v
+            vendors.append(f"{k.split('_')[0]}")
+    print(*Counter(vendors))
+
+
+def logger_config() -> dict:
+    """Create dict for logger configuration"""
+    log_config_dict = {
+        "version": 1,
+        "formatters": {
+            "simple": {"format": "%(asctime)s - %(levelname)s - %(message)s"}
+        },
+        "handlers": {
+            "stream": {
+                "class": "logging.StreamHandler",
+                "formatter": "simple",
+                "level": "DEBUG",
+                "stream": "ext://sys.stdout",
+            },
+            "file": {
+                "class": "logging.FileHandler",
+                "formatter": "simple",
+                "level": "DEBUG",
+                "filename": "file_retriever.log",
+            },
+        },
+        "loggers": {
+            "file_retriever": {"handlers": ["stream", "file"], "level": "DEBUG"}
+        },
+    }
+    return log_config_dict

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -12,20 +12,12 @@ def test_BaseClient():
     _BaseClient.__abstractmethods__ = set()
     ftp_bc = _BaseClient(username="foo", password="bar", host="baz", port=21)
     assert ftp_bc.__dict__ == {"connection": None}
-    assert ftp_bc.get_remote_file_data("foo.mrc", "bar") is None
-    assert ftp_bc.list_remote_file_data("foo") is None
+    assert ftp_bc.close() is None
     assert ftp_bc.download_file("foo.mrc", "bar", "baz") is None
+    assert ftp_bc.get_remote_file_data("foo.mrc", "bar") is None
+    assert ftp_bc.is_active() is None
+    assert ftp_bc.list_remote_file_data("foo") is None
     assert ftp_bc.upload_file("foo.mrc", "bar", "baz") is None
-
-
-def test_BaseClient_context_manager(mock_BaseClient):
-    _BaseClient.__abstractmethods__ = set()
-    with _BaseClient(username="foo", password="bar", host="baz", port=22) as sftp_bc:
-        assert sftp_bc.connection is not None
-        assert sftp_bc.get_remote_file_data("foo.mrc", "bar") is None
-        assert sftp_bc.list_remote_file_data("foo") is None
-        assert sftp_bc.download_file("foo.mrc", "bar", "baz") is None
-        assert sftp_bc.upload_file("foo.mrc", "bar", "baz") is None
 
 
 class TestMock_ftpClient:
@@ -35,11 +27,6 @@ class TestMock_ftpClient:
         stub_creds["port"] = "21"
         ftp = _ftpClient(**stub_creds)
         assert ftp.connection is not None
-
-    def test_ftpClient_context_manager(self, stub_client, stub_creds):
-        stub_creds["port"] = "21"
-        with _ftpClient(**stub_creds) as client:
-            assert client.connection is not None
 
     def test_ftpClient_no_creds(self, stub_client):
         creds = {}
@@ -55,6 +42,32 @@ class TestMock_ftpClient:
         stub_creds["port"] = "21"
         with pytest.raises(ftplib.error_temp):
             _ftpClient(**stub_creds)
+
+    def test_ftpClient_close(self, mock_ftpClient_sftpClient, stub_creds):
+        stub_creds["port"] = "21"
+        ftp = _ftpClient(**stub_creds)
+        connection = ftp.close()
+        assert connection is None
+
+    def test_ftpClient_download_file(self, mock_ftpClient_sftpClient, stub_creds):
+        stub_creds["port"] = "21"
+        with does_not_raise():
+            ftp = _ftpClient(**stub_creds)
+            ftp.download_file(file="foo.mrc", remote_dir="bar", local_dir="test")
+
+    def test_ftpClient_download_file_not_found(self, mock_file_error, stub_creds):
+        stub_creds["port"] = "21"
+        with pytest.raises(OSError):
+            ftp = _ftpClient(**stub_creds)
+            ftp.download_file(file="foo.mrc", remote_dir="bar", local_dir="test")
+
+    def test_ftpClient_download_connection_error(
+        self, mock_connection_error_reply, stub_creds
+    ):
+        stub_creds["port"] = "21"
+        with pytest.raises(ftplib.error_reply):
+            ftp = _ftpClient(**stub_creds)
+            ftp.download_file(file="foo.mrc", remote_dir="bar", local_dir="test")
 
     def test_ftpClient_get_remote_file_data(
         self, mock_ftpClient_sftpClient, stub_creds
@@ -96,6 +109,18 @@ class TestMock_ftpClient:
         with pytest.raises(ftplib.error_perm):
             ftp.get_remote_file_data("foo.mrc", "testdir")
 
+    def test_ftpClient_is_active(self, mock_ftpClient_sftpClient, stub_creds):
+        stub_creds["port"] = "21"
+        ftp = _ftpClient(**stub_creds)
+        live_connection = ftp.is_active()
+        assert live_connection is True
+
+    def test_ftpClient_is_inactive(self, mock_connection_dropped, stub_creds):
+        stub_creds["port"] = "21"
+        ftp = _ftpClient(**stub_creds)
+        live_connection = ftp.is_active()
+        assert live_connection is False
+
     def test_ftpClient_list_remote_file_data(
         self, mock_ftpClient_sftpClient, stub_creds
     ):
@@ -121,26 +146,6 @@ class TestMock_ftpClient:
         ftp = _ftpClient(**stub_creds)
         with pytest.raises(ftplib.error_reply):
             ftp.list_remote_file_data("testdir")
-
-    def test_ftpClient_download_file(self, mock_ftpClient_sftpClient, stub_creds):
-        stub_creds["port"] = "21"
-        with does_not_raise():
-            ftp = _ftpClient(**stub_creds)
-            ftp.download_file(file="foo.mrc", remote_dir="bar", local_dir="test")
-
-    def test_ftpClient_download_file_not_found(self, mock_file_error, stub_creds):
-        stub_creds["port"] = "21"
-        with pytest.raises(OSError):
-            ftp = _ftpClient(**stub_creds)
-            ftp.download_file(file="foo.mrc", remote_dir="bar", local_dir="test")
-
-    def test_ftpClient_download_connection_error(
-        self, mock_connection_error_reply, stub_creds
-    ):
-        stub_creds["port"] = "21"
-        with pytest.raises(ftplib.error_reply):
-            ftp = _ftpClient(**stub_creds)
-            ftp.download_file(file="foo.mrc", remote_dir="bar", local_dir="test")
 
     def test_ftpClient_upload_file(self, mock_ftpClient_sftpClient, stub_creds):
         stub_creds["port"] = "21"
@@ -186,10 +191,23 @@ class TestMock_sftpClient:
         with pytest.raises(paramiko.SSHException):
             _sftpClient(**stub_creds)
 
-    def test_sftpClient_context_manager(self, stub_client, stub_creds):
+    def test_ftpClient_close(self, mock_ftpClient_sftpClient, stub_creds):
         stub_creds["port"] = "22"
-        with _sftpClient(**stub_creds) as client:
-            assert client.connection is not None
+        sftp = _sftpClient(**stub_creds)
+        connection = sftp.close()
+        assert connection is None
+
+    def test_sftpClient_download_file(self, mock_ftpClient_sftpClient, stub_creds):
+        stub_creds["port"] = "22"
+        with does_not_raise():
+            sftp = _sftpClient(**stub_creds)
+            sftp.download_file(file="foo.mrc", remote_dir="bar", local_dir="test")
+
+    def test_sftpClient_download_file_not_found(self, mock_file_error, stub_creds):
+        stub_creds["port"] = "22"
+        sftp = _sftpClient(**stub_creds)
+        with pytest.raises(OSError):
+            sftp.download_file(file="foo.mrc", remote_dir="bar", local_dir="test")
 
     def test_sftpClient_get_remote_file_data(
         self, mock_ftpClient_sftpClient, stub_creds
@@ -214,6 +232,18 @@ class TestMock_sftpClient:
         sftp = _sftpClient(**stub_creds)
         with pytest.raises(OSError):
             sftp.get_remote_file_data("foo.mrc", "testdir")
+
+    def test_sftpClient_is_active(self, mock_ftpClient_sftpClient, stub_creds):
+        stub_creds["port"] = "22"
+        sftp = _sftpClient(**stub_creds)
+        live_connection = sftp.is_active()
+        assert live_connection is True
+
+    def test_sftpClient_is_inactive(self, mock_connection_dropped, stub_creds):
+        stub_creds["port"] = "22"
+        sftp = _sftpClient(**stub_creds)
+        live_connection = sftp.is_active()
+        assert live_connection is False
 
     def test_sftpClient_list_remote_file_data(
         self, mock_ftpClient_sftpClient, stub_creds
@@ -240,18 +270,6 @@ class TestMock_sftpClient:
         sftp = _sftpClient(**stub_creds)
         with pytest.raises(OSError):
             sftp.list_remote_file_data("testdir")
-
-    def test_sftpClient_download_file(self, mock_ftpClient_sftpClient, stub_creds):
-        stub_creds["port"] = "22"
-        with does_not_raise():
-            sftp = _sftpClient(**stub_creds)
-            sftp.download_file(file="foo.mrc", remote_dir="bar", local_dir="test")
-
-    def test_sftpClient_download_file_not_found(self, mock_file_error, stub_creds):
-        stub_creds["port"] = "22"
-        sftp = _sftpClient(**stub_creds)
-        with pytest.raises(OSError):
-            sftp.download_file(file="foo.mrc", remote_dir="bar", local_dir="test")
 
     def test_sftpClient_upload_file(self, mock_ftpClient_sftpClient, stub_creds):
         stub_creds["port"] = "22"
@@ -291,9 +309,7 @@ class TestLiveClients:
         with pytest.raises(ftplib.error_perm) as exc:
             live_ftp_creds["username"] = "bpl"
             _ftpClient(**live_ftp_creds)
-        assert "Unable to authenticate with server with provided credentials." in str(
-            exc
-        )
+        assert "Login incorrect" in str(exc)
 
     def test_sftpClient_live_test(self, live_sftp_creds):
         remote_dir = live_sftp_creds["remote_dir"]

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -41,12 +41,6 @@ class TestMock_ftpClient:
         with _ftpClient(**stub_creds) as client:
             assert client.connection is not None
 
-    @pytest.mark.parametrize("port", [None, [], {}])
-    def test_ftpClient_port_ValueError(self, stub_client, stub_creds, port):
-        stub_creds["port"] = port
-        with pytest.raises(ValueError):
-            _ftpClient(**stub_creds)
-
     def test_ftpClient_no_creds(self, stub_client):
         creds = {}
         with pytest.raises(TypeError):
@@ -176,12 +170,6 @@ class TestMock_sftpClient:
         stub_creds["port"] = "22"
         sftp = _sftpClient(**stub_creds)
         assert sftp.connection is not None
-
-    @pytest.mark.parametrize("port", [None, [], {}])
-    def test_sftpClient_port_ValueError(self, stub_client, stub_creds, port):
-        stub_creds["port"] = port
-        with pytest.raises(ValueError):
-            _sftpClient(**stub_creds)
 
     def test_sftpClient_no_creds(self, stub_client):
         creds = {}

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -67,6 +67,33 @@ class TestMockClient:
         "port",
         [21, 22],
     )
+    def test_Client_context_manager(self, mock_Client, stub_creds, port):
+        (
+            stub_creds["port"],
+            stub_creds["remote_dir"],
+            stub_creds["vendor"],
+        ) = (port, "testdir", "test")
+        with Client(**stub_creds) as connect:
+            assert connect.session is not None
+
+    @pytest.mark.parametrize(
+        "port",
+        [21, 22],
+    )
+    def test_Client_check_connection(self, mock_Client, stub_creds, port):
+        (
+            stub_creds["port"],
+            stub_creds["remote_dir"],
+            stub_creds["vendor"],
+        ) = (port, "testdir", "test")
+        connect = Client(**stub_creds)
+        live_connection = connect.check_connection()
+        assert live_connection is True
+
+    @pytest.mark.parametrize(
+        "port",
+        [21, 22],
+    )
     def test_Client_check_file_local(self, mock_Client_file_exists, stub_creds, port):
         (
             stub_creds["port"],

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -1,7 +1,9 @@
 import ftplib
 import paramiko
 import pytest
-from file_retriever.connect import Client, _ftpClient, _sftpClient, File
+from file_retriever.connect import Client
+from file_retriever._clients import _ftpClient, _sftpClient
+from file_retriever.file import File
 
 
 class TestMockClient:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,58 @@
+import datetime
+import logging
+import logging.config
+import os
+import pytest
+from file_retriever.utils import logger_config, vendor_config
+
+
+def test_logger_config():
+    config = logger_config()
+    assert config["version"] == 1
+    assert sorted(config["handlers"].keys()) == sorted(["stream", "file"])
+    assert config["handlers"]["file"]["filename"] == "file_retriever.log"
+
+
+@pytest.mark.parametrize(
+    "message, level", [("Test message", "INFO"), ("Debug message", "DEBUG")]
+)
+def test_logger_config_stream(message, level, caplog):
+    today = datetime.datetime.today().strftime("%Y-%m-%d")
+    config = logger_config()
+    config["handlers"]["file"] = {
+        "class": "logging.NullHandler",
+        "formatter": "simple",
+        "level": "DEBUG",
+    }
+    logging.config.dictConfig(config)
+    logger = logging.getLogger("file_retriever")
+    assert len(logger.handlers) == 2
+    logger.info("Test message")
+    logger.debug("Debug message")
+    records = [i for i in caplog.records]
+    log_messages = [i.message for i in records]
+    log_level = [i.levelname for i in records]
+    log_created = [i.asctime[:10] for i in records]
+    assert message in log_messages
+    assert level in log_level
+    assert today in log_created
+
+
+def test_vendor_config(mocker):
+    yaml_string = """
+        TEST_HOST: foo
+        TEST_USER: bar
+        TEST_PASSWORD: baz
+        TEST_PORT: '22'
+        TEST_SRC: test_src
+    """
+    m = mocker.mock_open(read_data=yaml_string)
+    mocker.patch("builtins.open", m)
+
+    vendor_config("foo.yaml")
+
+    assert os.environ["TEST_HOST"] == "foo"
+    assert os.environ["TEST_USER"] == "bar"
+    assert os.environ["TEST_PASSWORD"] == "baz"
+    assert os.environ["TEST_PORT"] == "22"
+    assert os.environ["TEST_SRC"] == "test_src"


### PR DESCRIPTION
Added:
 + logging to `Client`, `_ftpClient`, and `_sftpClient` classes
 + logger contains two handlers: stream and file to write logs to `sys.stdout` and file_retriever.log file
 + `close()` and `is_active()` methods to `_ftpClient` and `_sftpClient` classes
 + `check_connection()` method to `Client` class will determine if a server connection is still alive

Changed:
 + within `Client` class, `port` arg now accepts either a `str` or `int` rather than a `Literal[ 21, 22, "21", "22"]`
 + reordered methods within classes
 + `Client` class now has `__enter__` and `__exit__` methods to allow it to be used as a context manager rather than `_ftpClient` and `_sftpClient`. Refactored `Client` methods so they are not creating multiple context managers