### PR TITLE
Refactored client and file classes

### DIFF
--- a/file_retriever/_clients.py
+++ b/file_retriever/_clients.py
@@ -211,9 +211,7 @@ class _ftpClient(_BaseClient):
                 file_mtime=time[4:],
                 file_mode=permissions,
             )
-        except ftplib.error_perm as e:
-            # remove logging?
-            logger.error(f"Unable to retrieve file data for {file_name}: {e}")
+        except ftplib.error_perm:
             raise RetrieverFileError
 
     def list_file_data(self, dir: str) -> List[FileInfo]:
@@ -432,9 +430,7 @@ class _sftpClient(_BaseClient):
             return FileInfo.from_stat_data(
                 data=self.connection.stat(file_name), file_name=file_name
             )
-        except OSError as e:
-            # remove logging?
-            logger.error(f"Unable to retrieve file data for {file_name}: {e}")
+        except OSError:
             raise RetrieverFileError
 
     def list_file_data(self, dir: str) -> List[FileInfo]:

--- a/file_retriever/_clients.py
+++ b/file_retriever/_clients.py
@@ -198,23 +198,12 @@ class _ftpClient(_BaseClient):
                 permissions = data[0:10]
 
             self.connection.retrlines(f"LIST {file_name}", get_file_permissions),
-            if permissions is None:
-                logger.error(f"{file_name} not found on server.")
-                raise RetrieverFileError("File not found on server.")
-
-            # Retrieve file size
             size = self.connection.size(file_name)
-            if size is None:
-                logger.error(f"Unable to retrieve file size for {file_name}.")
-                raise RetrieverFileError("Unable to retrieve file size.")
-
-            # Retrieve file modification time
             time = self.connection.voidcmd(f"MDTM {file_name}")
-            if time is None:
-                logger.error(
-                    f"Unable to retrieve file modification time for {file_name}."
-                )
-                raise RetrieverFileError("Unable to retrieve file modification time.")
+
+            if permissions is None or size is None or time is None:
+                logger.error(f"Unable to retrieve file data for {file_name}.")
+                raise RetrieverFileError
 
             return FileInfo(
                 file_name=file_name,

--- a/file_retriever/_clients.py
+++ b/file_retriever/_clients.py
@@ -112,7 +112,6 @@ class _ftpClient(_BaseClient):
             ftplib.error_temp: if unable to connect to server
             ftplib.error_perm: if unable to authenticate with server
         """
-        logger.debug(f"Connecting to {host} via FTP client")
         try:
             ftp_client = ftplib.FTP()
             ftp_client.connect(host=host, port=port)
@@ -121,7 +120,6 @@ class _ftpClient(_BaseClient):
                 user=username,
                 passwd=password,
             )
-            logger.debug(f"Connected at {port} to {host}")
             return ftp_client
         except ftplib.error_perm as e:
             logger.error(f"Unable to authenticate with provided credentials: {e}")
@@ -133,7 +131,6 @@ class _ftpClient(_BaseClient):
     def _check_dir(self, dir: str) -> None:
         """Changes directory to `dir` if not already in `dir`."""
         if self.connection.pwd().lstrip("/") != dir.lstrip("/"):
-            logger.debug(f"Changing cwd to {dir}")
             self.connection.cwd(dir)
         else:
             pass
@@ -230,8 +227,7 @@ class _ftpClient(_BaseClient):
                 file_name = os.path.basename(data)
                 file = self.get_file_data(file_name=file_name, dir=dir)
                 files.append(file)
-        except ftplib.error_perm as e:
-            logger.error(f"Unable to retrieve file data for {dir}: {e}")
+        except ftplib.error_perm:
             raise RetrieverFileError
         return files
 
@@ -337,7 +333,6 @@ class _sftpClient(_BaseClient):
             paramiko.AuthenticationException: if unable to authenticate with server
 
         """
-        logger.debug(f"Connecting to {host} via SFTP client")
         try:
             ssh = paramiko.SSHClient()
             ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
@@ -348,7 +343,6 @@ class _sftpClient(_BaseClient):
                 password=password,
             )
             sftp_client = ssh.open_sftp()
-            logger.debug(f"Connected at {port} to {host}")
             return sftp_client
         except paramiko.AuthenticationException as e:
             logger.error(f"Unable to authenticate with provided credentials: {e}")
@@ -360,10 +354,8 @@ class _sftpClient(_BaseClient):
     def _check_dir(self, dir: str) -> None:
         wd = self.connection.getcwd()
         if wd is None:
-            logger.debug(f"Changing cwd to {dir}")
             self.connection.chdir(dir)
         elif isinstance(wd, str) and wd.lstrip("/") != dir.lstrip("/"):
-            logger.debug(f"Changing cwd to {dir}")
             self.connection.chdir(None)
             self.connection.chdir(dir)
         else:
@@ -419,8 +411,7 @@ class _sftpClient(_BaseClient):
             return FileInfo.from_stat_data(
                 data=self.connection.stat(file_name), file_name=file_name
             )
-        except OSError as e:
-            logger.error(f"Unable to retrieve file data for {file_name}: {e}")
+        except OSError:
             raise RetrieverFileError
 
     def list_file_data(self, dir: str) -> List[FileInfo]:

--- a/file_retriever/connect.py
+++ b/file_retriever/connect.py
@@ -209,12 +209,12 @@ class Client:
             time_delta = time_delta
         if not remote_dir or remote_dir is None:
             remote_dir = self.remote_dir
-        logger.debug(f"({self.name}) Listing all files in `{remote_dir}`")
+        logger.debug(f"({self.name}) Retrieving list of files in `{remote_dir}`")
         files = self.session.list_file_data(dir=remote_dir)
         if time_delta > datetime.timedelta(days=0):
             logger.debug(
                 f"({self.name}) Filtering list for files created "
-                f"since {today - time_delta}"
+                f"since {datetime.datetime.strftime((today - time_delta), '%Y-%m-%d')}"
             )
             recent_files = [
                 i

--- a/file_retriever/connect.py
+++ b/file_retriever/connect.py
@@ -113,7 +113,10 @@ class Client:
         else:
             return os.path.exists(os.path.join(dir, file))
 
-    def get_file(self, file: str, remote_dir: Optional[str] = None) -> io.BytesIO:
+    # def get_file(self, file: str, remote_dir: Optional[str] = None) -> io.BytesIO:
+    def get_file(
+        self, file: Union[File, List[File]], remote_dir: Optional[str] = None
+    ) -> Union[File, List[File]]:
         """
         Fetches `file` from `remote_dir` on server as bytes. If `remote_dir` is not
         provided then file will be fetched from `self.remote_dir`.
@@ -183,8 +186,8 @@ class Client:
             return files
 
     def put_file(
-        self, fh: io.BytesIO, file: str, dir: str, remote: bool, check: bool
-    ) -> File:
+        self, file: Union[File, List[File]], dir: str, remote: bool, check: bool
+    ) -> Union[File, List[File]]:
         """
         Writes fetched file to directory. If `remote` is True, then file is written
         to directory `dir` the Client server. If `remote` is False, then file is written
@@ -210,8 +213,11 @@ class Client:
             ftplib.error_perm: if unable to write file to directory
             OSError: if unable to write file to directory
         """
-        if check and self.file_exists(file, dir=dir, remote=True):
-            logger.error(f"{file} not written to {dir} because it already exists")
-            raise FileExistsError
+        # if check and self.file_exists(file.file_name, dir=dir, remote=True):
+        #     if isinstance(file, list):
+        #         logger.error(f"{file} not written to {dir} because it already exists")
+        #         raise FileExistsError
+        #     logger.error(f"{file} not written to {dir} because it already exists")
+        #     raise FileExistsError
         logger.debug(f"Writing {file} to {dir} directory")
-        return self.session.write_file(fh, file, dir, remote)
+        return self.session.write_file(file, dir, remote)

--- a/file_retriever/connect.py
+++ b/file_retriever/connect.py
@@ -23,7 +23,7 @@ class Client:
 
     def __init__(
         self,
-        vendor: str,
+        name: str,
         username: str,
         password: str,
         host: str,
@@ -33,15 +33,14 @@ class Client:
         """Initializes client instance.
 
         Args:
-            vendor: name of vendor
+            name: name of server or vendor (eg. 'leila', 'nsdrop')
             username: username for server
             password: password for server
             host: server address
             port: port number for server
             remote_dir: directory on server to interact with
         """
-
-        self.vendor = vendor
+        self.name = name
         self.host = host
         self.port = port
         self.remote_dir = remote_dir

--- a/file_retriever/connect.py
+++ b/file_retriever/connect.py
@@ -190,7 +190,7 @@ class Client:
         Returns:
             list of files in `remote_dir` represented as `FileInfo` objects
         """
-        today = datetime.datetime.now()
+        today = datetime.datetime.now(tz=datetime.timezone.utc)
 
         if not remote_dir or remote_dir is None:
             remote_dir = self.remote_dir

--- a/file_retriever/connect.py
+++ b/file_retriever/connect.py
@@ -208,14 +208,10 @@ class Client:
                 )
                 >= today - datetime.timedelta(days=time_delta)
             ]
-            if len(file_list) == 0:
-                logger.debug(f"({self.name}) No recent files in `{remote_dir}`")
-                return []
-            else:
-                logger.debug(
-                    f"({self.name}) {len(file_list)} recent files in `{remote_dir}`"
-                )
-                return file_list
+            logger.debug(
+                f"({self.name}) {len(file_list)} recent files in `{remote_dir}`"
+            )
+            return file_list
         else:
             logger.debug(f"({self.name}) {len(files)} in `{remote_dir}`")
             return files

--- a/file_retriever/connect.py
+++ b/file_retriever/connect.py
@@ -127,9 +127,7 @@ class Client:
         else:
             return os.path.exists(f"{dir}/{file.file_name}")
 
-    def get_file(
-        self, files: Union[FileInfo, List[FileInfo]], remote_dir: Optional[str] = None
-    ) -> Union[File, List[File]]:
+    def get_file(self, file: FileInfo, remote_dir: Optional[str] = None) -> File:
         """
         Fetches one or more files from `remote_dir` on server. If `remote_dir` is
         not provided then file will be fetched from `self.remote_dir`.
@@ -146,21 +144,10 @@ class Client:
         """
         if not remote_dir or remote_dir is None:
             remote_dir = self.remote_dir
-        if isinstance(files, list):
-            file_list = []
-            for file in files:
-                logger.debug(
-                    f"({self.name}) Fetching {file.file_name} from "
-                    f"`{remote_dir}` directory"
-                )
-                file_list.append(self.session.fetch_file(file=file, dir=remote_dir))
-            return file_list
-        else:
-            logger.debug(
-                f"({self.name}) Fetching {files.file_name} from "
-                f"`{remote_dir}` directory"
-            )
-            return self.session.fetch_file(file=files, dir=remote_dir)
+        logger.debug(
+            f"({self.name}) Fetching {file.file_name} from " f"`{remote_dir}` directory"
+        )
+        return self.session.fetch_file(file=file, dir=remote_dir)
 
     def get_file_info(
         self, file_name: str, remote_dir: Optional[str] = None
@@ -224,11 +211,11 @@ class Client:
 
     def put_file(
         self,
-        files: Union[File, List[File]],
+        file: File,
         dir: str,
         remote: bool,
         check: bool,
-    ) -> Optional[Union[FileInfo, List[FileInfo]]]:
+    ) -> Optional[FileInfo]:
         """
         Writes fetched file(s) to directory. Takes one or more `File` objects and
         writes them to `dir` directory. If `remote` is True, then file is written
@@ -260,38 +247,12 @@ class Client:
                 f"({self.name}) Checking for file in destination "
                 f"directory before writing"
             )
-        if isinstance(files, list):
-            get_files = []
-            for file in files:
-                if (
-                    check
-                    and self.file_exists(file=file, dir=dir, remote=remote) is True
-                ):
-                    logger.debug(
-                        f"({self.name}) Skipping {file.file_name}. File already "
-                        f"exists in {dir}."
-                    )
-                    continue
-                else:
-                    get_files.append(file)
-            written_files = []
-            for file in get_files:
-                logger.debug(
-                    f"({self.name}) Writing {file.file_name} to {dir} directory"
-                )
-                written_files.append(
-                    self.session.write_file(file=file, dir=dir, remote=remote)
-                )
-            return written_files
-        elif isinstance(files, FileInfo):
-            if check and self.file_exists(file=files, dir=dir, remote=remote) is True:
-                logger.debug(
-                    f"({self.name}) Skipping {files.file_name}. File already "
-                    f"exists in {dir}."
-                )
-                return None
-            else:
-                logger.debug(
-                    f"({self.name}) Writing {files.file_name} to {dir} directory"
-                )
-                return self.session.write_file(file=files, dir=dir, remote=remote)
+        if check and self.file_exists(file=file, dir=dir, remote=remote) is True:
+            logger.debug(
+                f"({self.name}) Skipping {file.file_name}. File already "
+                f"exists in {dir}."
+            )
+            return None
+        else:
+            logger.debug(f"({self.name}) Writing {file.file_name} to {dir} directory")
+            return self.session.write_file(file=file, dir=dir, remote=remote)

--- a/file_retriever/errors.py
+++ b/file_retriever/errors.py
@@ -1,8 +1,14 @@
-"""This module contains the custom exceptions for the file_retriever package."""
+"""This module contains custom exceptions for the file_retriever package."""
 
 
 class FileRetrieverError(Exception):
     """Base class for exceptions in the file_retriever package."""
+
+    pass
+
+
+class RetrieverAuthenticationError(FileRetrieverError):
+    """Exception raised for errors in authenticating to a server."""
 
     pass
 
@@ -13,13 +19,7 @@ class RetrieverConnectionError(FileRetrieverError):
     pass
 
 
-class RetrieverAuthenticationError(FileRetrieverError):
-    """Exception raised for errors in authenticating to the file server."""
-
-    pass
-
-
 class RetrieverFileError(FileRetrieverError):
-    """Exception raised for errors in finding the requested file."""
+    """Exception raised for errors in finding or accessing a requested file."""
 
     pass

--- a/file_retriever/errors.py
+++ b/file_retriever/errors.py
@@ -1,0 +1,25 @@
+"""This module contains the custom exceptions for the file_retriever package."""
+
+
+class FileRetrieverError(Exception):
+    """Base class for exceptions in the file_retriever package."""
+
+    pass
+
+
+class RetrieverConnectionError(FileRetrieverError):
+    """Exception raised for errors in connecting to the file server."""
+
+    pass
+
+
+class RetrieverAuthenticationError(FileRetrieverError):
+    """Exception raised for errors in authenticating to the file server."""
+
+    pass
+
+
+class RetrieverFileError(FileRetrieverError):
+    """Exception raised for errors in finding the requested file."""
+
+    pass

--- a/file_retriever/file.py
+++ b/file_retriever/file.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 import datetime
+import io
 import os
 import paramiko
 from typing import Optional, Union
@@ -16,6 +17,7 @@ class File:
     file_gid: Optional[int] = None
     file_atime: Optional[float] = None
     file_mode: Optional[int] = None
+    file_stream: Optional[io.BytesIO] = None
 
     @classmethod
     def from_stat_data(
@@ -54,13 +56,14 @@ class File:
             raise AttributeError("No file modification time provided")
 
         return cls(
-            filename,
-            data.st_mtime,
-            data.st_size,
-            data.st_uid,
-            data.st_gid,
-            data.st_atime,
-            data.st_mode,
+            file_name=filename,
+            file_mtime=data.st_mtime,
+            file_size=data.st_size,
+            file_uid=data.st_uid,
+            file_gid=data.st_gid,
+            file_atime=data.st_atime,
+            file_mode=data.st_mode,
+            file_stream=None,
         )
 
     @staticmethod

--- a/file_retriever/file.py
+++ b/file_retriever/file.py
@@ -1,3 +1,5 @@
+"""This module contains classes to store file metadata and content."""
+
 import datetime
 import io
 import os
@@ -6,18 +8,38 @@ from typing import Optional, Union
 
 
 class FileInfo:
-    """A class to store file information."""
+    """A class to store file metadata."""
 
     def __init__(
         self,
         file_name: str,
         file_mtime: Union[float, int, str],
         file_mode: Union[str, int],
-        file_size: Optional[int] = None,
+        file_size: int,
         file_uid: Optional[int] = None,
         file_gid: Optional[int] = None,
         file_atime: Optional[float] = None,
     ):
+        """Initialize `FileInfo` object with file metadata.
+
+        File metadata includes attributes included in `os.stat_result` and
+        `paramiko.SFTPAttributes` objects. The `file_mtime` attribute can be a
+        float, int or string. If it is a string, it is parsed to a timestamp
+        as an int. The `file_mode` attribute can be a string or int. If it is a
+        string, it is parsed to a decimal value. `file_uid`, `file_gid` and
+        `file_atime` are optional attribute as they are not always available,
+        especially for files accessed via FTP.
+
+        Args:
+
+            file_name: name of file
+            file_mtime: file modification time
+            file_mode: file permissions
+            file_size: file size
+            file_uid: file owner user id
+            file_gid: file owner group id
+            file_atime: file access time
+        """
         self.file_name = file_name
         self.file_size = file_size
         self.file_uid = file_uid
@@ -46,7 +68,7 @@ class FileInfo:
         methods.
 
         Args:
-            stat_result_data: data formatted like os.stat_result
+            data: data formatted like `os.stat_result` object
             file_name: name of file
 
         Returns:
@@ -68,36 +90,50 @@ class FileInfo:
 
         match data.st_mode:
             case data.st_mode if isinstance(data.st_mode, int):
-                mode: Union[str, int] = data.st_mode
+                st_mode: Union[str, int] = data.st_mode
             case data.st_mode if isinstance(
                 data, paramiko.SFTPAttributes
             ) and data.st_mode is None and hasattr(
                 data, "longname"
             ) and data.longname is not None:
-                mode = data.longname[0:10]
+                st_mode = data.longname[0:10]
             case _:
                 raise AttributeError("No file mode provided")
 
-        match data:
-            case data if hasattr(
-                data, "st_mtime"
-            ) and data.st_mtime is not None and isinstance(data.st_mtime, float | int):
-                st_mtime = data.st_mtime
-            case _:
-                raise AttributeError("No file modification time provided")
+        if hasattr(data, "st_size") and data.st_size is not None:
+            st_size = data.st_size
+        elif isinstance(data, paramiko.SFTPAttributes) and (
+            hasattr(data, "longname")
+            and data.longname is not None
+            and data.st_size is None
+        ):
+            raise AttributeError(
+                "No file size provided, size may be present in longname"
+            )
+        else:
+            raise AttributeError("No file size provided")
+
+        if (
+            hasattr(data, "st_mtime")
+            and data.st_mtime is not None
+            and isinstance(data.st_mtime, float | int)
+        ):
+            st_mtime = data.st_mtime
+        else:
+            raise AttributeError("No file modification time provided")
 
         return cls(
             file_name=file_name,
             file_mtime=st_mtime,
-            file_mode=mode,
-            file_size=data.st_size,
+            file_mode=st_mode,
+            file_size=st_size,
             file_uid=data.st_uid,
             file_gid=data.st_gid,
             file_atime=data.st_atime,
         )
 
     def __parse_mdtm_time(self, mdtm_time: str) -> int:
-        """parse string returned by MDTM command to timestamp as int."""
+        """parse date formatted as string (YYYYMMDDHHMMSS) to int timestamp."""
         return int(
             datetime.datetime.strptime(mdtm_time, "%Y%m%d%H%M%S")
             .replace(tzinfo=datetime.timezone.utc)
@@ -106,21 +142,38 @@ class FileInfo:
 
     def __parse_permissions(self, file_mode: str) -> int:
         """
-        parse permissions string to decimal value.
+        parse permissions written as string in symbolic notation
+        (eg. -rwxrwxrwx) to decimal value.
 
-        permissions:
-                a 10 character string representing the permissions associated with
-                a file. The first character represents the file type, the next 9
-                characters represent the permissions.
-                    eg. '-rw-rw-rw-'
-                this string is parsed to extract the file mode in decimal notation
-                using the following formula:
-                    digit 1 (filetype), digits 2-4 (owner permissions), digits 5-7
-                    (group permissions), and digits 8-10 (other permissions) are
-                    converted to octal value (eg: '-rwxrwxrwx' -> 100777) the octal
-                    number is then converted to a decimal value:
-                        (filetype * 8^5) + (0 * 8^4) + (0 * 8^3) + (owner * 8^2) +
-                        (group * 8^1) + (others * 8^0) = decimal value
+        file_mode:
+            a 10 character string representing the permissions associated with
+            a file. The first character represents the file type, the next 9
+            characters represent the owner, group, and public permissions.
+                eg. '-rwxrw-r--'
+            this string is parsed calculate the file's permission mode in
+            decimal notation using the following formula:
+                digit 1 (filetype):
+                    the first character is converted to an octal value based
+                    on the type:
+                        d -> 4 (directory)
+                        - -> 1 (file)
+                digits 2-10 (permissions by group):
+                    within each group (2-4: owner, 5-7: group, and 8-10: public),
+                    each digit is converted to an octal value:
+                        r -> 4 (read)
+                        w -> 2 (write)
+                        x -> 1 (execute)
+                        - -> 0 (no permission)
+                    the octal values for each group of 3 characters are then added
+                        'rwxrwxrwx' -> '(4+2+1) (4+2+1) (4+2+1)' -> 777
+                the octal values of the file type and permissions are then converted
+                to a decimal value using the following formula:
+                    (filetype * 8^5) + (0 * 8^4) + (0 * 8^3) + (owner * 8^2) +
+                    (group * 8^1) + (others * 8^0) = decimal value
+                    example:
+                        '-rwxrw-r--' -> 100764
+                        (1 * 8^5) + (0 * 8^4) + (0 * 8^3) +
+                        (7 * 8^2) + (6 * 8^1) + (4 * 8^0) = 33264
         """
         file_type = file_mode[0].replace("d", "4").replace("-", "1")
         file_perm = (
@@ -141,19 +194,36 @@ class FileInfo:
 
 
 class File(FileInfo):
-    """A class to store file information and data stream."""
+    """A class to store file metadata and data stream."""
 
     def __init__(
         self,
         file_name: str,
         file_mtime: Union[float, str],
         file_mode: Union[str, int],
+        file_size: int,
         file_stream: io.BytesIO,
-        file_size: Optional[int] = None,
         file_uid: Optional[int] = None,
         file_gid: Optional[int] = None,
         file_atime: Optional[float] = None,
     ):
+        """Initialize `File` object with file metadata and data stream.
+
+        File metadata includes attributes inherited from `FileInfo` class.
+        The `file_stream` attribute is a `io.BytesIO` object containing the
+        content of the file.
+
+        Args:
+
+            file_name: name of file
+            file_mtime: file modification time
+            file_mode: file permissions
+            file_size: file size
+            file_stream: file stream as `io.BytesIO`
+            file_uid: file owner user id
+            file_gid: file owner group id
+            file_atime: file access time
+        """
         super().__init__(
             file_name=file_name,
             file_mtime=file_mtime,
@@ -182,8 +252,8 @@ class File(FileInfo):
             file_mtime=file.file_mtime,
             file_mode=file.file_mode,
             file_size=file.file_size,
+            file_stream=file_stream,
             file_uid=file.file_uid,
             file_gid=file.file_gid,
             file_atime=file.file_atime,
-            file_stream=file_stream,
         )

--- a/file_retriever/file.py
+++ b/file_retriever/file.py
@@ -7,7 +7,7 @@ from typing import Optional, Union
 
 
 @dataclass
-class File:
+class FileInfo:
     """A dataclass to store file information."""
 
     file_name: str
@@ -24,18 +24,19 @@ class File:
         cls,
         data: Union[os.stat_result, paramiko.SFTPAttributes],
         file_name: Optional[str] = None,
-    ) -> "File":
+    ) -> "FileInfo":
         """
-        Creates a `File` object from `os.stat_result` or `paramiko.SFTPAttributes` data.
-        Accepts data returned by `paramiko.SFTPClient.stat`, `paramiko.SFTPClient.put`,
-        `paramiko.SFTPClient.listdir_attr` or `os.stat` methods.
+        Creates a `FileInfo` object from `os.stat_result` or `paramiko.SFTPAttributes`
+        data. Accepts data returned by `paramiko.SFTPClient.stat`,
+        `paramiko.SFTPClient.put`, `paramiko.SFTPClient.listdir_attr` or `os.stat`
+        methods.
 
         Args:
             stat_result_data: data formatted like os.stat_result
             file_name: name of file
 
         Returns:
-            `File` object
+            `FileInfo` object
         """
         if file_name is not None:
             filename = file_name

--- a/file_retriever/file.py
+++ b/file_retriever/file.py
@@ -102,14 +102,6 @@ class FileInfo:
 
         if hasattr(data, "st_size") and data.st_size is not None:
             st_size = data.st_size
-        elif isinstance(data, paramiko.SFTPAttributes) and (
-            hasattr(data, "longname")
-            and data.longname is not None
-            and data.st_size is None
-        ):
-            raise AttributeError(
-                "No file size provided, size may be present in longname"
-            )
         else:
             raise AttributeError("No file size provided")
 

--- a/file_retriever/utils.py
+++ b/file_retriever/utils.py
@@ -6,7 +6,20 @@ import yaml
 
 
 def logger_config() -> dict:
-    """Create and return dict for logger configuration"""
+    """
+    Create and return dict for logger configuration.
+
+    INFO and DEBUG logs are recorded in methods of the `Client` class while
+    ERROR logs are primarily recorded in methods of the `_ftpClient` and
+    `_sftpClient` classes. The one exception to this is ERROR messages
+    logged by the `_ftpClient` and `_sftpClient` `get_file_data` methods.
+    These are logged as errors in the `Client` class in order avoid logging
+    errors when files are not found by the `Client.file_exists` method.
+
+    Returns:
+        dict: dictionary with logger configuration
+
+    """
     log_config_dict = {
         "version": 1,
         "formatters": {

--- a/file_retriever/utils.py
+++ b/file_retriever/utils.py
@@ -1,4 +1,5 @@
 import os
+from typing import List
 import yaml
 
 
@@ -30,9 +31,22 @@ def logger_config() -> dict:
     return log_config_dict
 
 
-def vendor_config(config_path: str) -> None:
-    """Set environment variables from config file"""
+def client_config(config_path: str) -> List[str]:
+    """
+    Set environment variables from config file. Returns a list of vendors
+    whose credentials are stored in the config file and have been added to
+    the environment.
+
+    Args:
+        config_path (str): Path to the config file.
+
+    Returns:
+        list of vendors whose credentials are stored in the config file and
+        have been added to the environment.
+    """
     with open(config_path, "r") as file:
         config = yaml.safe_load(file)
         for k, v in config.items():
             os.environ[k] = v
+        vendor_list = [i.strip("_HOST") for i in config.keys() if i.endswith("_HOST")]
+        return vendor_list

--- a/file_retriever/utils.py
+++ b/file_retriever/utils.py
@@ -1,10 +1,12 @@
+"""This module contains helper functions for the file_retriever package."""
+
 import os
 from typing import List
 import yaml
 
 
 def logger_config() -> dict:
-    """Create dict for logger configuration"""
+    """Create and return dict for logger configuration"""
     log_config_dict = {
         "version": 1,
         "formatters": {
@@ -33,16 +35,16 @@ def logger_config() -> dict:
 
 def client_config(config_path: str) -> List[str]:
     """
-    Set environment variables from config file. Returns a list of vendors
-    whose credentials are stored in the config file and have been added to
-    the environment.
+    Read config file with credentials and set creds as environment variables.
+    Returns a list of names for servers whose credentials are stored in the
+    config file and have been added to env vars.
 
     Args:
-        config_path (str): Path to the config file.
+        config_path (str): Path to the yaml file with credendtials.
 
     Returns:
-        list of vendors whose credentials are stored in the config file and
-        have been added to the environment.
+        list of names of servers (eg. EASTVIEW, NSDROP) whose credentials are
+        stored in the config file and have been added to env vars
     """
     with open(config_path, "r") as file:
         config = yaml.safe_load(file)

--- a/file_retriever/utils.py
+++ b/file_retriever/utils.py
@@ -48,5 +48,7 @@ def client_config(config_path: str) -> List[str]:
         config = yaml.safe_load(file)
         for k, v in config.items():
             os.environ[k] = v
-        vendor_list = [i.strip("_HOST") for i in config.keys() if i.endswith("_HOST")]
+        vendor_list = [
+            i.split("_HOST")[0] for i in config.keys() if i.endswith("_HOST")
+        ]
         return vendor_list

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -276,7 +276,7 @@ def live_ftp_creds() -> Dict[str, str]:
             "password": data["LEILA_PASSWORD"],
             "host": data["LEILA_HOST"],
             "port": data["LEILA_PORT"],
-            "vendor": "leila",
+            "name": "leila",
             "remote_dir": data["LEILA_SRC"],
         }
 
@@ -292,7 +292,7 @@ def live_sftp_creds() -> Dict[str, str]:
             "password": data["EASTVIEW_PASSWORD"],
             "host": data["EASTVIEW_HOST"],
             "port": data["EASTVIEW_PORT"],
-            "vendor": "eastview",
+            "name": "eastview",
             "remote_dir": data["EASTVIEW_SRC"],
         }
 
@@ -307,7 +307,7 @@ def NSDROP_creds() -> Dict[str, str]:
             "username": data["NSDROP_USER"],
             "password": data["NSDROP_PASSWORD"],
             "host": data["NSDROP_HOST"],
-            "port": "22",
-            "vendor": "nsdrop",
-            "remote_dir": ".",
+            "port": data["NSDROP_PORT"],
+            "name": "nsdrop",
+            "remote_dir": data["NSDROP_SRC"],
         }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ import yaml
 import pytest
 from file_retriever._clients import _ftpClient, _sftpClient, _BaseClient
 from file_retriever.connect import Client
+from file_retriever.file import File
 
 logger = logging.getLogger("file_retriever")
 
@@ -50,11 +51,18 @@ class MockFileData:
 
 
 @pytest.fixture
-def mock_file_data(monkeypatch):
-    def mock_stat(*args, **kwargs):
-        return MockFileData()
-
-    monkeypatch.setattr(os, "stat", mock_stat)
+def mock_file_data():
+    file = MockFileData()
+    return File(
+        file.file_name,
+        file.st_mtime,
+        file.st_size,
+        file.st_uid,
+        file.st_gid,
+        file.st_atime,
+        file.st_mode,
+        None,
+    )
 
 
 @pytest.fixture
@@ -156,13 +164,17 @@ def stub_client(monkeypatch):
 
 
 @pytest.fixture
-def mock_ftpClient_sftpClient(monkeypatch, mock_open_file, stub_client, mock_file_data):
+def mock_ftpClient_sftpClient(monkeypatch, mock_open_file, stub_client):
     def mock_ftp_client(*args, **kwargs):
         return MockFTP()
 
     def mock_sftp_client(*args, **kwargs):
         return MockSFTPClient()
 
+    def mock_stat(*args, **kwargs):
+        return MockFileData()
+
+    monkeypatch.setattr(os, "stat", mock_stat)
     monkeypatch.setattr(_ftpClient, "_connect_to_server", mock_ftp_client)
     monkeypatch.setattr(_sftpClient, "_connect_to_server", mock_sftp_client)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -267,20 +267,31 @@ def mock_file_error(monkeypatch, mock_open_file, mock_ftpClient_sftpClient):
     def mock_ftp_error_perm(*args, **kwargs):
         raise ftplib.error_perm
 
-    def mock_retrlines(*args, **kwargs):
+    def mock_none_return(*args, **kwargs):
         return None
 
-    monkeypatch.setattr(MockFTP, "voidcmd", mock_ftp_error_perm)
-    monkeypatch.setattr(MockFTP, "size", mock_ftp_error_perm)
-    monkeypatch.setattr(MockFTP, "nlst", mock_ftp_error_perm)
-    monkeypatch.setattr(MockFTP, "retrlines", mock_retrlines)
-    monkeypatch.setattr(MockFTP, "retrbinary", mock_ftp_error_perm)
-    monkeypatch.setattr(MockFTP, "storbinary", mock_ftp_error_perm)
     monkeypatch.setattr(MockSFTPClient, "stat", mock_os_error)
     monkeypatch.setattr(MockSFTPClient, "getfo", mock_os_error)
     monkeypatch.setattr(MockSFTPClient, "putfo", mock_os_error)
     monkeypatch.setattr(MockSFTPClient, "listdir_attr", mock_os_error)
     monkeypatch.setattr(os, "stat", mock_os_error)
+    monkeypatch.setattr(MockFTP, "voidcmd", mock_ftp_error_perm)
+    monkeypatch.setattr(MockFTP, "nlst", mock_ftp_error_perm)
+    monkeypatch.setattr(MockFTP, "retrbinary", mock_ftp_error_perm)
+    monkeypatch.setattr(MockFTP, "storbinary", mock_ftp_error_perm)
+    monkeypatch.setattr(MockFTP, "size", mock_ftp_error_perm)
+    monkeypatch.setattr(MockFTP, "retrlines", mock_none_return)
+
+
+@pytest.fixture
+def mock_ftp_file_not_found(monkeypatch, mock_open_file, mock_ftpClient_sftpClient):
+    def mock_none_return(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(MockFTP, "voidcmd", mock_none_return)
+    monkeypatch.setattr(MockFTP, "nlst", mock_none_return)
+    monkeypatch.setattr(MockFTP, "size", mock_none_return)
+    monkeypatch.setattr(MockFTP, "retrlines", mock_none_return)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,8 +15,8 @@ logger = logging.getLogger("file_retriever")
 
 class FakeUtcNow(datetime.datetime):
     @classmethod
-    def now(cls, tzinfo=datetime.timezone.utc):
-        return cls(2024, 6, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
+    def now(cls, tz=datetime.timezone.utc):
+        return cls(2024, 6, 1, 1, 0, 0, 0, datetime.timezone.utc)
 
 
 class MockChannel:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,13 +56,13 @@ class MockFileData:
 
     def file_info(self):
         return FileInfo(
-            self.file_name,
-            self.st_mtime,
-            self.st_size,
-            self.st_uid,
-            self.st_gid,
-            self.st_atime,
-            self.st_mode,
+            file_name=self.file_name,
+            file_mtime=self.st_mtime,
+            file_size=self.st_size,
+            file_uid=self.st_uid,
+            file_gid=self.st_gid,
+            file_atime=self.st_atime,
+            file_mode=self.st_mode,
         )
 
     def os_stat_result(self):
@@ -103,7 +103,7 @@ class MockFTP:
         return pathname
 
     def nlst(self, *args, **kwargs) -> List[str]:
-        return ["foo.mrc"]
+        return [MockFileData().file_name]
 
     def pwd(self, *args, **kwargs) -> str:
         return "/"
@@ -117,7 +117,7 @@ class MockFTP:
         return args[1](files)
 
     def size(self, *args, **kwargs) -> int:
-        return 140401
+        return MockFileData().st_size
 
     def storbinary(self, *args, **kwargs) -> None:
         pass
@@ -138,9 +138,6 @@ class MockSFTPClient:
     def close(self, *args, **kwargs) -> None:
         pass
 
-    def get(self, remotepath, localpath, *args, **kwargs) -> None:
-        open(localpath, "x+")
-
     def get_channel(self, *args, **kwargs) -> MockChannel:
         return MockChannel()
 
@@ -152,9 +149,6 @@ class MockSFTPClient:
 
     def listdir_attr(self, *args, **kwargs) -> List[paramiko.SFTPAttributes]:
         return [MockFileData().sftp_attr()]
-
-    def put(self, *args, **kwargs) -> paramiko.SFTPAttributes:
-        return MockFileData().sftp_attr()
 
     def putfo(self, *args, **kwargs) -> paramiko.SFTPAttributes:
         return MockFileData().sftp_attr()
@@ -278,13 +272,12 @@ def mock_file_error(monkeypatch, mock_open_file, mock_ftpClient_sftpClient):
 
     monkeypatch.setattr(MockFTP, "voidcmd", mock_ftp_error_perm)
     monkeypatch.setattr(MockFTP, "size", mock_ftp_error_perm)
+    monkeypatch.setattr(MockFTP, "nlst", mock_ftp_error_perm)
     monkeypatch.setattr(MockFTP, "retrlines", mock_retrlines)
     monkeypatch.setattr(MockFTP, "retrbinary", mock_ftp_error_perm)
     monkeypatch.setattr(MockFTP, "storbinary", mock_ftp_error_perm)
     monkeypatch.setattr(MockSFTPClient, "stat", mock_os_error)
-    monkeypatch.setattr(MockSFTPClient, "get", mock_os_error)
     monkeypatch.setattr(MockSFTPClient, "getfo", mock_os_error)
-    monkeypatch.setattr(MockSFTPClient, "put", mock_os_error)
     monkeypatch.setattr(MockSFTPClient, "putfo", mock_os_error)
     monkeypatch.setattr(MockSFTPClient, "listdir_attr", mock_os_error)
     monkeypatch.setattr(os, "stat", mock_os_error)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,26 +43,47 @@ class MockFileData:
         self.st_uid = 0
         self.st_size = 140401
 
-    def create_SFTPAttributes(self):
+    def sftp_attr(self):
         sftp_attr = paramiko.SFTPAttributes()
-        sftp_attr.__dict__ = self.__dict__
         sftp_attr.filename = self.file_name
+        sftp_attr.st_mtime = self.st_mtime
+        sftp_attr.st_mode = self.st_mode
+        sftp_attr.st_atime = self.st_atime
+        sftp_attr.st_gid = self.st_gid
+        sftp_attr.st_uid = self.st_uid
+        sftp_attr.st_size = self.st_size
         return sftp_attr
+
+    def file_info(self):
+        return FileInfo(
+            self.file_name,
+            self.st_mtime,
+            self.st_size,
+            self.st_uid,
+            self.st_gid,
+            self.st_atime,
+            self.st_mode,
+        )
+
+    def os_stat_result(self):
+        result = os.stat_result()
+        result.st_mtime = self.st_mtime
+        result.st_mode = self.st_mode
+        result.st_atime = self.st_atime
+        result.st_gid = self.st_gid
+        result.st_uid = self.st_uid
+        result.st_size = self.st_size
+        return result
 
 
 @pytest.fixture
-def mock_file_data():
-    file = MockFileData()
-    return FileInfo(
-        file.file_name,
-        file.st_mtime,
-        file.st_size,
-        file.st_uid,
-        file.st_gid,
-        file.st_atime,
-        file.st_mode,
-        None,
-    )
+def mock_sftp_attr():
+    return MockFileData().sftp_attr()
+
+
+@pytest.fixture
+def mock_file_info():
+    return MockFileData().file_info()
 
 
 @pytest.fixture
@@ -130,16 +151,16 @@ class MockSFTPClient:
         return fl.write(b"00000")
 
     def listdir_attr(self, *args, **kwargs) -> List[paramiko.SFTPAttributes]:
-        return [MockFileData().create_SFTPAttributes()]
+        return [MockFileData().sftp_attr()]
 
     def put(self, *args, **kwargs) -> paramiko.SFTPAttributes:
-        return MockFileData().create_SFTPAttributes()
+        return MockFileData().sftp_attr()
 
     def putfo(self, *args, **kwargs) -> paramiko.SFTPAttributes:
-        return MockFileData().create_SFTPAttributes()
+        return MockFileData().sftp_attr()
 
     def stat(self, *args, **kwargs) -> paramiko.SFTPAttributes:
-        return MockFileData().create_SFTPAttributes()
+        return MockFileData().sftp_attr()
 
 
 class MockABCClient:

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -54,11 +54,11 @@ class TestMock_ftpClient:
         with pytest.raises(RetrieverConnectionError):
             _ftpClient(**stub_creds)
 
-    def test_ftpClient_check_dir(self, mock_ftpClient_sftpClient, stub_creds, caplog):
+    def test_ftpClient_check_dir(self, mock_ftpClient_sftpClient, stub_creds):
         stub_creds["port"] = "21"
         ftp = _ftpClient(**stub_creds)
-        ftp._check_dir(dir="foo")
-        assert "Changing cwd to foo" in caplog.text
+        with does_not_raise():
+            ftp._check_dir(dir="foo")
 
     def test_ftpClient_check_dir_cwd(self, mock_cwd, stub_creds):
         stub_creds["port"] = "21"
@@ -204,46 +204,23 @@ class TestMock_sftpClient:
         with pytest.raises(RetrieverConnectionError):
             _sftpClient(**stub_creds)
 
-    def test_sftpClient_check_dir(self, mock_ftpClient_sftpClient, stub_creds, caplog):
+    def test_sftpClient_check_dir(self, mock_ftpClient_sftpClient, stub_creds):
         stub_creds["port"] = "22"
         sftp = _sftpClient(**stub_creds)
-        sftp._check_dir(dir="foo")
-        assert "Changing cwd to foo" in caplog.text
+        with does_not_raise():
+            sftp._check_dir(dir="foo")
 
-    def test_sftpClient_check_dir_cwd(self, mock_cwd, stub_creds, caplog):
+    def test_sftpClient_check_dir_cwd(self, mock_cwd, stub_creds):
         stub_creds["port"] = "22"
         sftp = _sftpClient(**stub_creds)
         with does_not_raise():
             sftp._check_dir(dir="/")
 
-    def test_sftpClient_check_dir_other_dir(self, mock_other_dir, stub_creds, caplog):
+    def test_sftpClient_check_dir_other_dir(self, mock_other_dir, stub_creds):
         stub_creds["port"] = "22"
         sftp = _sftpClient(**stub_creds)
-        sftp._check_dir(dir="foo")
-        assert caplog.records[0] is not None
-        assert "Changing cwd to foo" in caplog.text
-
-    # def test_sftpClient_check_file_exists_false(
-    #     self, mock_ftpClient_sftpClient, stub_creds
-    # ):
-    #     stub_creds["port"] = "22"
-    #     sftp = _sftpClient(**stub_creds)
-    #     exists = sftp.check_file_exists(file_name="foo.mrc", dir="testdir")
-    #     assert exists is False
-
-    # def test_sftpClient_check_file_exists_true(
-    #     self, mock_Client_file_exists, stub_creds
-    # ):
-    #     stub_creds["port"] = "22"
-    #     sftp = _sftpClient(**stub_creds)
-    #     exists = sftp.check_file_exists(file_name="foo.mrc", dir="testdir")
-    #     assert exists is True
-
-    # def test_sftpClient_check_file_exists_error(self, mock_file_error, stub_creds):
-    #     stub_creds["port"] = "22"
-    #     sftp = _sftpClient(**stub_creds)
-    #     exists = sftp.check_file_exists(file_name="foo.mrc", dir="testdir")
-    #     assert exists is False
+        with does_not_raise():
+            sftp._check_dir(dir="foo")
 
     def test_sftpClient_close(self, mock_ftpClient_sftpClient, stub_creds):
         stub_creds["port"] = "22"

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -106,6 +106,14 @@ class TestMock_ftpClient:
         with pytest.raises(RetrieverFileError):
             ftp.get_file_data(file_name="foo.mrc", dir="testdir")
 
+    def test_ftpClient_get_file_data_file_not_found(
+        self, mock_ftp_file_not_found, stub_creds
+    ):
+        stub_creds["port"] = "21"
+        ftp = _ftpClient(**stub_creds)
+        with pytest.raises(RetrieverFileError):
+            ftp.get_file_data(file_name="foo.mrc", dir="testdir")
+
     def test_ftpClient_list_file_data(self, mock_ftpClient_sftpClient, stub_creds):
         stub_creds["port"] = "21"
         ftp = _ftpClient(**stub_creds)

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -385,7 +385,7 @@ class TestLiveClients:
         ) >= datetime.datetime(2020, 1, 1)
         assert len(file_list) > 1
         assert file_data.file_size > 1
-        assert file_data.file_mode > 33000
+        assert file_data.file_mode > 32768
         assert fetched_file.file_stream.getvalue()[0:1] == b"0"
 
     def test_sftpClient_live_test_auth_error(self, live_sftp_creds):

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -21,8 +21,8 @@ def test_BaseClient(mock_file_info):
     assert ftp_bc._check_dir(dir="foo") is None
     assert ftp_bc.close() is None
     assert ftp_bc.fetch_file(file="foo.mrc", dir="bar") is None
-    assert ftp_bc.get_remote_file_data(file="foo.mrc", dir="bar") is None
-    assert ftp_bc.get_remote_file_list(dir="foo") is None
+    assert ftp_bc.get_file_data(file_name="foo.mrc", dir="bar") is None
+    assert ftp_bc.list_file_data(dir="foo") is None
     assert ftp_bc.is_active() is None
     assert ftp_bc.write_file(file=mock_file_info, dir="bar", remote=True) is None
 
@@ -84,12 +84,10 @@ class TestMock_ftpClient:
             ftp = _ftpClient(**stub_creds)
             ftp.fetch_file(file=mock_file_info, dir="bar")
 
-    def test_ftpClient_get_remote_file_data(
-        self, mock_ftpClient_sftpClient, stub_creds
-    ):
+    def test_ftpClient_get_file_data(self, mock_ftpClient_sftpClient, stub_creds):
         stub_creds["port"] = "21"
         ftp = _ftpClient(**stub_creds)
-        file_data = ftp.get_remote_file_data(file="foo.mrc", dir="testdir")
+        file_data = ftp.get_file_data(file_name="foo.mrc", dir="testdir")
         assert file_data.file_name == "foo.mrc"
         assert file_data.file_mtime == 1704070800
         assert file_data.file_size == 140401
@@ -98,20 +96,16 @@ class TestMock_ftpClient:
         assert file_data.file_gid is None
         assert file_data.file_atime is None
 
-    def test_ftpClient_get_remote_file_data_error_perm(
-        self, mock_file_error, stub_creds
-    ):
+    def test_ftpClient_get_file_data_error_perm(self, mock_file_error, stub_creds):
         stub_creds["port"] = "21"
         ftp = _ftpClient(**stub_creds)
         with pytest.raises(ftplib.error_perm):
-            ftp.get_remote_file_data(file="foo.mrc", dir="testdir")
+            ftp.get_file_data(file_name="foo.mrc", dir="testdir")
 
-    def test_ftpClient_get_remote_file_list(
-        self, mock_ftpClient_sftpClient, stub_creds
-    ):
+    def test_ftpClient_list_file_data(self, mock_ftpClient_sftpClient, stub_creds):
         stub_creds["port"] = "21"
         ftp = _ftpClient(**stub_creds)
-        files = ftp.get_remote_file_list(dir="testdir")
+        files = ftp.list_file_data(dir="testdir")
         assert all(isinstance(file, FileInfo) for file in files)
         assert len(files) == 1
         assert files[0].file_name == "foo.mrc"
@@ -122,13 +116,11 @@ class TestMock_ftpClient:
         assert files[0].file_gid is None
         assert files[0].file_atime is None
 
-    def test_ftpClient_get_remote_file_list_error_perm(
-        self, mock_file_error, stub_creds
-    ):
+    def test_ftpClient_list_file_data_error_perm(self, mock_file_error, stub_creds):
         stub_creds["port"] = "21"
         ftp = _ftpClient(**stub_creds)
         with pytest.raises(ftplib.error_perm):
-            ftp.get_remote_file_list(dir="testdir")
+            ftp.list_file_data(dir="testdir")
 
     def test_ftpClient_is_active_true(self, mock_ftpClient_sftpClient, stub_creds):
         stub_creds["port"] = "21"
@@ -249,12 +241,10 @@ class TestMock_sftpClient:
         with pytest.raises(OSError):
             sftp.fetch_file(file=mock_file_info, dir="bar")
 
-    def test_sftpClient_get_remote_file_data(
-        self, mock_ftpClient_sftpClient, stub_creds
-    ):
+    def test_sftpClient_get_file_data(self, mock_ftpClient_sftpClient, stub_creds):
         stub_creds["port"] = "22"
         ftp = _sftpClient(**stub_creds)
-        file_data = ftp.get_remote_file_data(file="foo.mrc", dir="testdir")
+        file_data = ftp.get_file_data(file_name="foo.mrc", dir="testdir")
         assert file_data.file_name == "foo.mrc"
         assert file_data.file_mtime == 1704070800
         assert file_data.file_size == 140401
@@ -263,20 +253,16 @@ class TestMock_sftpClient:
         assert file_data.file_gid == 0
         assert file_data.file_atime is None
 
-    def test_sftpClient_get_remote_file_data_not_found(
-        self, mock_file_error, stub_creds
-    ):
+    def test_sftpClient_get_file_data_not_found(self, mock_file_error, stub_creds):
         stub_creds["port"] = "22"
         sftp = _sftpClient(**stub_creds)
         with pytest.raises(OSError):
-            sftp.get_remote_file_data(file="foo.mrc", dir="testdir")
+            sftp.get_file_data(file_name="foo.mrc", dir="testdir")
 
-    def test_sftpClient_get_remote_file_list(
-        self, mock_ftpClient_sftpClient, stub_creds
-    ):
+    def test_sftpClient_list_file_data(self, mock_ftpClient_sftpClient, stub_creds):
         stub_creds["port"] = "22"
         ftp = _sftpClient(**stub_creds)
-        files = ftp.get_remote_file_list(dir="testdir")
+        files = ftp.list_file_data(dir="testdir")
         assert all(isinstance(file, FileInfo) for file in files)
         assert len(files) == 1
         assert files[0].file_name == "foo.mrc"
@@ -287,13 +273,11 @@ class TestMock_sftpClient:
         assert files[0].file_gid == 0
         assert files[0].file_atime is None
 
-    def test_sftpClient_get_remote_file_list_not_found(
-        self, mock_file_error, stub_creds
-    ):
+    def test_sftpClient_list_file_data_not_found(self, mock_file_error, stub_creds):
         stub_creds["port"] = "22"
         sftp = _sftpClient(**stub_creds)
         with pytest.raises(OSError):
-            sftp.get_remote_file_list(dir="testdir")
+            sftp.list_file_data(dir="testdir")
 
     def test_sftpClient_is_active_true(self, mock_ftpClient_sftpClient, stub_creds):
         stub_creds["port"] = "22"
@@ -360,10 +344,10 @@ class TestLiveClients:
         remote_dir = live_ftp_creds["remote_dir"]
         del live_ftp_creds["remote_dir"], live_ftp_creds["name"]
         live_ftp = _ftpClient(**live_ftp_creds)
-        file_list = live_ftp.get_remote_file_list(dir=remote_dir)
+        file_list = live_ftp.list_file_data(dir=remote_dir)
         file_names = [file.file_name for file in file_list]
-        file_data = live_ftp.get_remote_file_data(
-            file="Sample_Full_RDA.mrc", dir=remote_dir
+        file_data = live_ftp.get_file_data(
+            file_name="Sample_Full_RDA.mrc", dir=remote_dir
         )
         fetched_file = live_ftp.fetch_file(file_data, remote_dir)
         assert "Sample_Full_RDA.mrc" in file_names
@@ -389,9 +373,9 @@ class TestLiveClients:
         remote_dir = live_sftp_creds["remote_dir"]
         del live_sftp_creds["remote_dir"], live_sftp_creds["name"]
         live_sftp = _sftpClient(**live_sftp_creds)
-        file_list = live_sftp.get_remote_file_list(dir=remote_dir)
-        file_data = live_sftp.get_remote_file_data(
-            file=file_list[0].file_name, dir=remote_dir
+        file_list = live_sftp.list_file_data(dir=remote_dir)
+        file_data = live_sftp.get_file_data(
+            file_name=file_list[0].file_name, dir=remote_dir
         )
         fetched_file = live_sftp.fetch_file(file=file_data, dir=remote_dir)
         assert live_sftp.connection.get_channel().active == 1
@@ -414,7 +398,7 @@ class TestLiveClients:
         remote_dir = "NSDROP/file_retriever_test/test_vendor"
         del NSDROP_creds["remote_dir"], NSDROP_creds["name"]
         live_sftp = _sftpClient(**NSDROP_creds)
-        get_file = live_sftp.get_remote_file_data(file="test.txt", dir=remote_dir)
+        get_file = live_sftp.get_file_data(file_name="test.txt", dir=remote_dir)
         fetched_file = live_sftp.fetch_file(file=get_file, dir=remote_dir)
         assert fetched_file.file_stream.getvalue() == b""
         assert get_file.file_name == "test.txt"

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -1,9 +1,17 @@
 import ftplib
+import io
 import paramiko
+import logging
+import logging.config
 import pytest
 from file_retriever.connect import Client
 from file_retriever._clients import _ftpClient, _sftpClient
 from file_retriever.file import File
+from file_retriever.utils import logger_config
+
+logger = logging.getLogger("file_retriever")
+config = logger_config()
+logging.config.dictConfig(config)
 
 
 class TestMockClient:
@@ -94,42 +102,56 @@ class TestMockClient:
         "port",
         [21, 22],
     )
-    def test_Client_check_file_local(self, mock_Client_file_exists, stub_creds, port):
+    def test_Client_file_exists_true_local(
+        self, mock_Client_file_exists, stub_creds, port
+    ):
         (
             stub_creds["port"],
             stub_creds["remote_dir"],
             stub_creds["vendor"],
         ) = (port, "testdir", "test")
         connect = Client(**stub_creds)
-        file_exists = connect.check_file(file="foo.mrc", check_dir="bar", remote=False)
+        file_exists = connect.file_exists(file="foo.mrc", dir="bar", remote=False)
         assert file_exists is True
 
     @pytest.mark.parametrize(
         "port",
         [21, 22],
     )
-    def test_Client_check_file_remote(self, mock_Client_file_exists, stub_creds, port):
+    def test_Client_file_exists_true_remote(
+        self, mock_Client_file_exists, stub_creds, port
+    ):
         (
             stub_creds["port"],
             stub_creds["remote_dir"],
             stub_creds["vendor"],
         ) = (port, "testdir", "test")
         connect = Client(**stub_creds)
-        file_exists = connect.check_file(file="foo.mrc", check_dir="bar", remote=True)
+        file_exists = connect.file_exists(file="foo.mrc", dir="bar", remote=True)
         assert file_exists is True
+
+    def test_Client_file_exists_sftp_file_not_found(self, mock_file_error, stub_creds):
+        (
+            stub_creds["port"],
+            stub_creds["remote_dir"],
+            stub_creds["vendor"],
+        ) = (22, "testdir", "test")
+        connect = Client(**stub_creds)
+        file_exists = connect.file_exists(file="foo.mrc", dir="bar", remote=True)
+        assert file_exists is False
 
     @pytest.mark.parametrize(
         "port, dir, uid_gid",
         [(21, "testdir", None), (21, None, None), (22, "testdir", 0), (22, None, 0)],
     )
-    def test_Client_get_file_data(self, mock_Client, stub_creds, port, dir, uid_gid):
+    def test_Client_get_file_info(self, mock_Client, stub_creds, port, dir, uid_gid):
         (
             stub_creds["port"],
             stub_creds["remote_dir"],
             stub_creds["vendor"],
         ) = (port, "testdir", "test")
         connect = Client(**stub_creds)
-        file = connect.get_file_data(file="foo.mrc", remote_dir=dir)
+        file = connect.get_file_info(file="foo.mrc", remote_dir=dir)
         assert file == File(
             file_name="foo.mrc",
             file_mtime=1704070800,
@@ -140,19 +162,17 @@ class TestMockClient:
             file_atime=None,
         )
 
-    def test_Client_ftp_get_file_data_not_found(
-        self, mock_connection_error_reply, stub_creds
-    ):
+    def test_Client_ftp_get_file_info_not_found(self, mock_file_error, stub_creds):
         (
             stub_creds["port"],
             stub_creds["remote_dir"],
             stub_creds["vendor"],
         ) = (21, "testdir", "test")
         connect = Client(**stub_creds)
-        with pytest.raises(ftplib.error_reply):
-            connect.get_file_data("foo.mrc", "testdir")
+        with pytest.raises(ftplib.error_perm):
+            connect.get_file_info("foo.mrc", "testdir")
 
-    def test_Client_sftp_get_file_data_not_found(self, mock_file_error, stub_creds):
+    def test_Client_sftp_get_file_info_not_found(self, mock_file_error, stub_creds):
         (
             stub_creds["port"],
             stub_creds["remote_dir"],
@@ -160,18 +180,18 @@ class TestMockClient:
         ) = (22, "testdir", "test")
         connect = Client(**stub_creds)
         with pytest.raises(OSError):
-            connect.get_file_data("foo.mrc", "testdir")
+            connect.get_file_info("foo.mrc", "testdir")
 
     @pytest.mark.parametrize("port, uid_gid", [(21, None), (22, 0)])
-    def test_Client_list_files_in_dir(self, mock_Client, stub_creds, port, uid_gid):
+    def test_Client_list_remote_dir(self, mock_Client, stub_creds, port, uid_gid):
         (
             stub_creds["port"],
             stub_creds["remote_dir"],
             stub_creds["vendor"],
         ) = (port, "testdir", "test")
         connect = Client(**stub_creds)
-        all_files = connect.list_files_in_dir()
-        recent_files = connect.list_files_in_dir(time_delta=5, remote_dir="testdir")
+        all_files = connect.list_remote_dir()
+        recent_files = connect.list_remote_dir(time_delta=5, remote_dir="testdir")
         assert all_files == [
             File(
                 file_name="foo.mrc",
@@ -195,7 +215,7 @@ class TestMockClient:
         ) = (21, "testdir", "test")
         connect = Client(**stub_creds)
         with pytest.raises(ftplib.error_reply):
-            connect.list_files_in_dir()
+            connect.list_remote_dir()
 
     def test_Client_list_sftp_file_not_found(self, mock_file_error, stub_creds):
         (
@@ -205,7 +225,7 @@ class TestMockClient:
         ) = (22, "testdir", "test")
         connect = Client(**stub_creds)
         with pytest.raises(OSError):
-            connect.list_files_in_dir()
+            connect.list_remote_dir()
 
     @pytest.mark.parametrize(
         "port, dir",
@@ -218,18 +238,8 @@ class TestMockClient:
             stub_creds["vendor"],
         ) = (port, "testdir", "test")
         connect = Client(**stub_creds)
-        downloaded_file = connect.get_file(
-            "foo.mrc", remote_dir=dir, local_dir="baz_dir", check=False
-        )
-        assert downloaded_file == File(
-            file_name="foo.mrc",
-            file_mtime=1704070800,
-            file_size=140401,
-            file_mode=33188,
-            file_uid=0,
-            file_gid=0,
-            file_atime=None,
-        )
+        downloaded_file = connect.get_file("foo.mrc", remote_dir=dir)
+        assert isinstance(downloaded_file, io.BytesIO)
 
     def test_Client_ftp_get_file_permissions_error(self, mock_file_error, stub_creds):
         (
@@ -239,9 +249,7 @@ class TestMockClient:
         ) = (21, "testdir", "test")
         connect = Client(**stub_creds)
         with pytest.raises(ftplib.error_perm):
-            connect.get_file(
-                "foo.mrc", remote_dir="bar_dir", local_dir="baz_dir", check=False
-            )
+            connect.get_file("foo.mrc", remote_dir="bar_dir")
 
     def test_Client_sftp_get_file_not_found(self, mock_file_error, stub_creds):
         (
@@ -251,120 +259,82 @@ class TestMockClient:
         ) = (22, "testdir", "test")
         connect = Client(**stub_creds)
         with pytest.raises(OSError):
-            connect.get_file(
-                "foo.mrc", remote_dir="bar_dir", local_dir="baz_dir", check=False
-            )
+            connect.get_file("foo.mrc", remote_dir="bar_dir")
 
     @pytest.mark.parametrize(
-        "port",
-        [21, 22],
+        "port, check",
+        [(21, True), (21, False), (22, True), (22, False)],
     )
-    def test_Client_get_check_file_exists_true(
-        self, mock_Client_file_exists, stub_creds, port
-    ):
+    def test_Client_put_file(self, mock_Client, stub_creds, port, check):
         (
             stub_creds["port"],
             stub_creds["remote_dir"],
             stub_creds["vendor"],
         ) = (port, "testdir", "test")
         connect = Client(**stub_creds)
-        with pytest.raises(FileExistsError):
-            connect.get_file("foo.mrc", "testdir", check=True)
+        fetched_file = io.BytesIO(b"0")
+        local_file = connect.put_file(
+            fh=fetched_file, file="foo.mrc", dir="bar", remote=False, check=check
+        )
+        remote_file = connect.put_file(
+            fh=fetched_file, file="foo.mrc", dir="bar", remote=True, check=check
+        )
+        assert remote_file.file_mtime == 1704070800
+        assert local_file.file_mtime == 1704070800
 
-    @pytest.mark.parametrize(
-        "port, dir",
-        [(21, "testdir"), (21, None), (22, "testdir"), (22, None)],
-    )
-    def test_Client_get_check_file_exists_false(
-        self, mock_Client, stub_creds, port, dir
+    def test_Client_ftp_put_file_permissions_error_remote(
+        self, mock_file_error, stub_creds
     ):
-        (
-            stub_creds["port"],
-            stub_creds["remote_dir"],
-            stub_creds["vendor"],
-        ) = (port, "testdir", "test")
-        connect = Client(**stub_creds)
-        downloaded_file = connect.get_file(
-            "foo.mrc", remote_dir=dir, local_dir="baz_dir", check=True
-        )
-        assert downloaded_file == File(
-            file_name="foo.mrc",
-            file_mtime=1704070800,
-            file_size=140401,
-            file_mode=33188,
-            file_uid=0,
-            file_gid=0,
-            file_atime=None,
-        )
-
-    @pytest.mark.parametrize(
-        "port, dir, uid_gid",
-        [(21, None, None), (21, "test", None), (22, None, 0), (22, "test", 0)],
-    )
-    def test_Client_put_file(self, mock_Client, stub_creds, port, dir, uid_gid):
-        (
-            stub_creds["port"],
-            stub_creds["remote_dir"],
-            stub_creds["vendor"],
-        ) = (port, "foo", "test")
-        connect = Client(**stub_creds)
-        put_file = connect.put_file(
-            "foo.mrc", remote_dir=dir, local_dir="baz_dir", check=False
-        )
-        assert put_file == File(
-            file_name="foo.mrc",
-            file_mtime=1704070800,
-            file_size=140401,
-            file_mode=33188,
-            file_uid=uid_gid,
-            file_gid=uid_gid,
-            file_atime=None,
-        )
-
-    def test_Client_ftp_put_file_not_found(self, mock_file_error, stub_creds):
         (
             stub_creds["port"],
             stub_creds["remote_dir"],
             stub_creds["vendor"],
         ) = (21, "testdir", "test")
         connect = Client(**stub_creds)
+        fetched_file = io.BytesIO(b"0")
         with pytest.raises(ftplib.error_perm):
             connect.put_file(
-                "foo.mrc", remote_dir="bar_dir", local_dir="baz_dir", check=False
+                fh=fetched_file, file="foo.mrc", dir="bar", remote=True, check=False
             )
 
-    def test_Client_sftp_put_file_not_found(self, mock_file_error, stub_creds):
+    def test_Client_ftp_put_file_permissions_error_local(
+        self, mock_file_error, stub_creds
+    ):
+        (
+            stub_creds["port"],
+            stub_creds["remote_dir"],
+            stub_creds["vendor"],
+        ) = (21, "testdir", "test")
+        connect = Client(**stub_creds)
+        fetched_file = io.BytesIO(b"0")
+        with pytest.raises(OSError):
+            connect.put_file(
+                fh=fetched_file, file="foo.mrc", dir="bar", remote=False, check=False
+            )
+
+    @pytest.mark.parametrize(
+        "remote",
+        [True, False],
+    )
+    def test_Client_sftp_put_file_not_found(self, mock_file_error, stub_creds, remote):
         (
             stub_creds["port"],
             stub_creds["remote_dir"],
             stub_creds["vendor"],
         ) = (22, "testdir", "test")
         connect = Client(**stub_creds)
+        fetched_file = io.BytesIO(b"0")
         with pytest.raises(OSError):
             connect.put_file(
-                "foo.mrc", remote_dir="bar_dir", local_dir="baz_dir", check=False
-            )
-
-    def test_Client_put_client_error_reply(
-        self, mock_connection_error_reply, stub_creds
-    ):
-        (
-            stub_creds["port"],
-            stub_creds["remote_dir"],
-            stub_creds["vendor"],
-        ) = (21, "testdir", "test")
-        client = Client(**stub_creds)
-        with pytest.raises(ftplib.error_reply):
-            client.put_file(
-                "foo.mrc", remote_dir="bar_dir", local_dir="baz_dir", check=False
+                fh=fetched_file, file="foo.mrc", dir="bar", remote=remote, check=False
             )
 
     @pytest.mark.parametrize(
-        "port",
-        [21, 22],
+        "port, remote",
+        [(21, True), (21, False), (22, True), (22, False)],
     )
-    def test_Client_put_check_file_exists_true(
-        self, mock_Client_file_exists, stub_creds, port
+    def test_Client_put_file_exists(
+        self, mock_Client_file_exists, stub_creds, port, remote
     ):
         (
             stub_creds["port"],
@@ -372,42 +342,17 @@ class TestMockClient:
             stub_creds["vendor"],
         ) = (port, "testdir", "test")
         connect = Client(**stub_creds)
+        fetched_file = io.BytesIO(b"0")
         with pytest.raises(FileExistsError):
             connect.put_file(
-                "foo.mrc", remote_dir="bar_dir", local_dir="baz_dir", check=True
+                fh=fetched_file, file="foo.mrc", dir="bar", remote=remote, check=True
             )
-
-    @pytest.mark.parametrize(
-        "port, uid_gid",
-        [(21, None), (22, 0)],
-    )
-    def test_Client_put_check_file_exists_false(
-        self, mock_Client, stub_creds, port, uid_gid
-    ):
-        (
-            stub_creds["port"],
-            stub_creds["remote_dir"],
-            stub_creds["vendor"],
-        ) = (port, "testdir", "test")
-        connect = Client(**stub_creds)
-        uploaded_file = connect.put_file(
-            "foo.mrc", remote_dir="bar_dir", local_dir="baz_dir", check=True
-        )
-        assert uploaded_file == File(
-            file_name="foo.mrc",
-            file_mtime=1704070800,
-            file_size=140401,
-            file_mode=33188,
-            file_gid=uid_gid,
-            file_uid=uid_gid,
-            file_atime=None,
-        )
 
 
 @pytest.mark.livetest
 def test_Client_ftp_live_test(live_ftp_creds):
     live_ftp = Client(**live_ftp_creds)
-    files = live_ftp.list_files_in_dir()
+    files = live_ftp.list_remote_dir()
     assert len(files) > 1
     assert "220" in live_ftp.session.connection.getwelcome()
 
@@ -415,6 +360,29 @@ def test_Client_ftp_live_test(live_ftp_creds):
 @pytest.mark.livetest
 def test_Client_sftp_live_test(live_sftp_creds):
     live_sftp = Client(**live_sftp_creds)
-    files = live_sftp.list_files_in_dir()
+    files = live_sftp.list_remote_dir()
     assert len(files) > 1
     assert live_sftp.session.connection.get_channel().active == 1
+
+
+@pytest.mark.livetest
+def test_Client_ftp_NSDROP(live_ftp_creds, NSDROP_creds):
+    with Client(**NSDROP_creds) as nsdrop:
+        with Client(**live_ftp_creds) as vendor_client:
+            logger.debug("Download")
+            downloaded_file = vendor_client.get_file(
+                "Sample_Full_RDA.mrc", live_ftp_creds["remote_dir"]
+            )
+            logger.debug("Write")
+            nsdrop.put_file(
+                downloaded_file,
+                "Sample_Full_RDA.mrc",
+                "NSDROP/file_retriever_test/test_vendor",
+                remote=True,
+                check=False,
+            )
+            logger.debug("Get")
+            get_file = nsdrop.get_file_info(
+                "Sample_Full_RDA.mrc", "NSDROP/file_retriever_test/test_vendor"
+            )
+            assert "Sample_Full_RDA.mrc" == get_file.file_name

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -163,8 +163,8 @@ class TestMockClient:
             multiple_files[1].file_stream,
             multiple_files[2].file_stream,
         ) = (io.BytesIO(b"0"), io.BytesIO(b"1"), io.BytesIO(b"2"))
-        file = connect.get_file(single_file, remote_dir=dir)
-        files = connect.get_file(multiple_files, remote_dir=dir)
+        file = connect.get_file(files=single_file, remote_dir=dir)
+        files = connect.get_file(files=multiple_files, remote_dir=dir)
         assert isinstance(file, File)
         assert len(files) == 3
         assert all(isinstance(f, File) for f in files)
@@ -180,7 +180,7 @@ class TestMockClient:
         connect = Client(**stub_creds)
         file_obj = File.from_fileinfo(file=mock_file_info, file_stream=io.BytesIO(b"0"))
         with pytest.raises(ftplib.error_perm):
-            connect.get_file(file_obj, remote_dir="bar_dir")
+            connect.get_file(files=file_obj, remote_dir="bar_dir")
 
     def test_Client_sftp_get_file_not_found(
         self, mock_file_error, mock_file_info, stub_creds
@@ -193,7 +193,7 @@ class TestMockClient:
         connect = Client(**stub_creds)
         file_obj = File.from_fileinfo(file=mock_file_info, file_stream=io.BytesIO(b"0"))
         with pytest.raises(OSError):
-            connect.get_file(file_obj, remote_dir="bar_dir")
+            connect.get_file(files=file_obj, remote_dir="bar_dir")
 
     @pytest.mark.parametrize(
         "port, dir, uid_gid",
@@ -234,7 +234,7 @@ class TestMockClient:
         ) = (22, "testdir", "test")
         connect = Client(**stub_creds)
         with pytest.raises(OSError):
-            connect.get_file_info("foo.mrc", "testdir")
+            connect.get_file_info(file="foo.mrc", remote_dir="testdir")
 
     @pytest.mark.parametrize("port, uid_gid", [(21, None), (22, 0)])
     def test_Client_list_file_info(self, mock_Client, stub_creds, port, uid_gid):

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -34,10 +34,10 @@ class TestMockClient:
         (
             stub_creds["port"],
             stub_creds["remote_dir"],
-            stub_creds["vendor"],
+            stub_creds["name"],
         ) = (port, "testdir", "test")
         connect = Client(**stub_creds)
-        assert connect.vendor == "test"
+        assert connect.name == "test"
         assert connect.host == "ftp.testvendor.com"
         assert connect.port == port
         assert connect.remote_dir == "testdir"
@@ -47,7 +47,7 @@ class TestMockClient:
         (
             stub_creds["port"],
             stub_creds["remote_dir"],
-            stub_creds["vendor"],
+            stub_creds["name"],
         ) = (1, "testdir", "test")
         with pytest.raises(ValueError) as e:
             Client(**stub_creds)
@@ -57,7 +57,7 @@ class TestMockClient:
         (
             stub_creds["port"],
             stub_creds["remote_dir"],
-            stub_creds["vendor"],
+            stub_creds["name"],
         ) = (21, "testdir", "test")
         with pytest.raises(ftplib.error_perm):
             Client(**stub_creds)
@@ -66,7 +66,7 @@ class TestMockClient:
         (
             stub_creds["port"],
             stub_creds["remote_dir"],
-            stub_creds["vendor"],
+            stub_creds["name"],
         ) = (22, "testdir", "test")
         with pytest.raises(paramiko.AuthenticationException):
             Client(**stub_creds)
@@ -79,7 +79,7 @@ class TestMockClient:
         (
             stub_creds["port"],
             stub_creds["remote_dir"],
-            stub_creds["vendor"],
+            stub_creds["name"],
         ) = (port, "testdir", "test")
         with Client(**stub_creds) as connect:
             assert connect.session is not None
@@ -92,7 +92,7 @@ class TestMockClient:
         (
             stub_creds["port"],
             stub_creds["remote_dir"],
-            stub_creds["vendor"],
+            stub_creds["name"],
         ) = (port, "testdir", "test")
         connect = Client(**stub_creds)
         live_connection = connect.check_connection()
@@ -108,7 +108,7 @@ class TestMockClient:
         (
             stub_creds["port"],
             stub_creds["remote_dir"],
-            stub_creds["vendor"],
+            stub_creds["name"],
         ) = (port, "testdir", "test")
         connect = Client(**stub_creds)
         file_exists = connect.file_exists(file="foo.mrc", dir="bar", remote=False)
@@ -124,7 +124,7 @@ class TestMockClient:
         (
             stub_creds["port"],
             stub_creds["remote_dir"],
-            stub_creds["vendor"],
+            stub_creds["name"],
         ) = (port, "testdir", "test")
         connect = Client(**stub_creds)
         file_exists = connect.file_exists(file="foo.mrc", dir="bar", remote=True)
@@ -134,7 +134,7 @@ class TestMockClient:
         (
             stub_creds["port"],
             stub_creds["remote_dir"],
-            stub_creds["vendor"],
+            stub_creds["name"],
         ) = (22, "testdir", "test")
         connect = Client(**stub_creds)
         file_exists = connect.file_exists(file="foo.mrc", dir="bar", remote=True)
@@ -148,7 +148,7 @@ class TestMockClient:
         (
             stub_creds["port"],
             stub_creds["remote_dir"],
-            stub_creds["vendor"],
+            stub_creds["name"],
         ) = (port, "testdir", "test")
         connect = Client(**stub_creds)
         file = connect.get_file_info(file="foo.mrc", remote_dir=dir)
@@ -166,7 +166,7 @@ class TestMockClient:
         (
             stub_creds["port"],
             stub_creds["remote_dir"],
-            stub_creds["vendor"],
+            stub_creds["name"],
         ) = (21, "testdir", "test")
         connect = Client(**stub_creds)
         with pytest.raises(ftplib.error_perm):
@@ -176,7 +176,7 @@ class TestMockClient:
         (
             stub_creds["port"],
             stub_creds["remote_dir"],
-            stub_creds["vendor"],
+            stub_creds["name"],
         ) = (22, "testdir", "test")
         connect = Client(**stub_creds)
         with pytest.raises(OSError):
@@ -187,7 +187,7 @@ class TestMockClient:
         (
             stub_creds["port"],
             stub_creds["remote_dir"],
-            stub_creds["vendor"],
+            stub_creds["name"],
         ) = (port, "testdir", "test")
         connect = Client(**stub_creds)
         all_files = connect.list_remote_dir()
@@ -211,7 +211,7 @@ class TestMockClient:
         (
             stub_creds["port"],
             stub_creds["remote_dir"],
-            stub_creds["vendor"],
+            stub_creds["name"],
         ) = (21, "testdir", "test")
         connect = Client(**stub_creds)
         with pytest.raises(ftplib.error_reply):
@@ -221,7 +221,7 @@ class TestMockClient:
         (
             stub_creds["port"],
             stub_creds["remote_dir"],
-            stub_creds["vendor"],
+            stub_creds["name"],
         ) = (22, "testdir", "test")
         connect = Client(**stub_creds)
         with pytest.raises(OSError):
@@ -235,7 +235,7 @@ class TestMockClient:
         (
             stub_creds["port"],
             stub_creds["remote_dir"],
-            stub_creds["vendor"],
+            stub_creds["name"],
         ) = (port, "testdir", "test")
         connect = Client(**stub_creds)
         downloaded_file = connect.get_file("foo.mrc", remote_dir=dir)
@@ -245,7 +245,7 @@ class TestMockClient:
         (
             stub_creds["port"],
             stub_creds["remote_dir"],
-            stub_creds["vendor"],
+            stub_creds["name"],
         ) = (21, "testdir", "test")
         connect = Client(**stub_creds)
         with pytest.raises(ftplib.error_perm):
@@ -255,7 +255,7 @@ class TestMockClient:
         (
             stub_creds["port"],
             stub_creds["remote_dir"],
-            stub_creds["vendor"],
+            stub_creds["name"],
         ) = (22, "testdir", "test")
         connect = Client(**stub_creds)
         with pytest.raises(OSError):
@@ -269,7 +269,7 @@ class TestMockClient:
         (
             stub_creds["port"],
             stub_creds["remote_dir"],
-            stub_creds["vendor"],
+            stub_creds["name"],
         ) = (port, "testdir", "test")
         connect = Client(**stub_creds)
         fetched_file = io.BytesIO(b"0")
@@ -288,7 +288,7 @@ class TestMockClient:
         (
             stub_creds["port"],
             stub_creds["remote_dir"],
-            stub_creds["vendor"],
+            stub_creds["name"],
         ) = (21, "testdir", "test")
         connect = Client(**stub_creds)
         fetched_file = io.BytesIO(b"0")
@@ -303,7 +303,7 @@ class TestMockClient:
         (
             stub_creds["port"],
             stub_creds["remote_dir"],
-            stub_creds["vendor"],
+            stub_creds["name"],
         ) = (21, "testdir", "test")
         connect = Client(**stub_creds)
         fetched_file = io.BytesIO(b"0")
@@ -320,7 +320,7 @@ class TestMockClient:
         (
             stub_creds["port"],
             stub_creds["remote_dir"],
-            stub_creds["vendor"],
+            stub_creds["name"],
         ) = (22, "testdir", "test")
         connect = Client(**stub_creds)
         fetched_file = io.BytesIO(b"0")
@@ -339,7 +339,7 @@ class TestMockClient:
         (
             stub_creds["port"],
             stub_creds["remote_dir"],
-            stub_creds["vendor"],
+            stub_creds["name"],
         ) = (port, "testdir", "test")
         connect = Client(**stub_creds)
         fetched_file = io.BytesIO(b"0")

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -231,13 +231,24 @@ class TestMockClient:
             file_atime=None,
         )
 
-    @pytest.mark.parametrize("port", [21, 22])
-    def test_Client_get_file_not_found(self, mock_file_error, stub_creds, port):
+    def test_Client_ftp_get_file_permissions_error(self, mock_file_error, stub_creds):
         (
             stub_creds["port"],
             stub_creds["remote_dir"],
             stub_creds["vendor"],
-        ) = (port, "testdir", "test")
+        ) = (21, "testdir", "test")
+        connect = Client(**stub_creds)
+        with pytest.raises(ftplib.error_perm):
+            connect.get_file(
+                "foo.mrc", remote_dir="bar_dir", local_dir="baz_dir", check=False
+            )
+
+    def test_Client_sftp_get_file_not_found(self, mock_file_error, stub_creds):
+        (
+            stub_creds["port"],
+            stub_creds["remote_dir"],
+            stub_creds["vendor"],
+        ) = (22, "testdir", "test")
         connect = Client(**stub_creds)
         with pytest.raises(OSError):
             connect.get_file(
@@ -310,13 +321,24 @@ class TestMockClient:
             file_atime=None,
         )
 
-    @pytest.mark.parametrize("port", [21, 22])
-    def test_Client_put_file_not_found(self, mock_file_error, stub_creds, port):
+    def test_Client_ftp_put_file_not_found(self, mock_file_error, stub_creds):
         (
             stub_creds["port"],
             stub_creds["remote_dir"],
             stub_creds["vendor"],
-        ) = (port, "testdir", "test")
+        ) = (21, "testdir", "test")
+        connect = Client(**stub_creds)
+        with pytest.raises(ftplib.error_perm):
+            connect.put_file(
+                "foo.mrc", remote_dir="bar_dir", local_dir="baz_dir", check=False
+            )
+
+    def test_Client_sftp_put_file_not_found(self, mock_file_error, stub_creds):
+        (
+            stub_creds["port"],
+            stub_creds["remote_dir"],
+            stub_creds["vendor"],
+        ) = (22, "testdir", "test")
         connect = Client(**stub_creds)
         with pytest.raises(OSError):
             connect.put_file(

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -231,15 +231,15 @@ class TestMockClient:
         "port, dir",
         [(21, "testdir"), (21, None), (22, "testdir"), (22, None)],
     )
-    def test_Client_get_file(self, mock_Client, stub_creds, port, dir):
+    def test_Client_get_file(self, mock_Client, mock_file_data, stub_creds, port, dir):
         (
             stub_creds["port"],
             stub_creds["remote_dir"],
             stub_creds["name"],
         ) = (port, "testdir", "test")
         connect = Client(**stub_creds)
-        downloaded_file = connect.get_file("foo.mrc", remote_dir=dir)
-        assert isinstance(downloaded_file, io.BytesIO)
+        downloaded_file = connect.get_file(mock_file_data, remote_dir=dir)
+        assert isinstance(downloaded_file, File)
 
     def test_Client_ftp_get_file_permissions_error(self, mock_file_error, stub_creds):
         (
@@ -251,7 +251,9 @@ class TestMockClient:
         with pytest.raises(ftplib.error_perm):
             connect.get_file("foo.mrc", remote_dir="bar_dir")
 
-    def test_Client_sftp_get_file_not_found(self, mock_file_error, stub_creds):
+    def test_Client_sftp_get_file_not_found(
+        self, mock_file_error, mock_file_data, stub_creds
+    ):
         (
             stub_creds["port"],
             stub_creds["remote_dir"],
@@ -259,7 +261,7 @@ class TestMockClient:
         ) = (22, "testdir", "test")
         connect = Client(**stub_creds)
         with pytest.raises(OSError):
-            connect.get_file("foo.mrc", remote_dir="bar_dir")
+            connect.get_file(mock_file_data, remote_dir="bar_dir")
 
     @pytest.mark.parametrize(
         "port, check",

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -1,3 +1,4 @@
+import datetime
 import io
 import logging
 import logging.config
@@ -228,11 +229,16 @@ class TestMockClient:
         ) = (port, "testdir", "test")
         connect = Client(**stub_creds)
         all_files = connect.list_file_info()
-        recent_files = connect.list_file_info(time_delta=5, remote_dir="testdir")
+        recent_files_int = connect.list_file_info(time_delta=5, remote_dir="testdir")
+        recent_files_dt = connect.list_file_info(
+            time_delta=datetime.timedelta(days=5), remote_dir="testdir"
+        )
         assert all(isinstance(file, FileInfo) for file in all_files)
-        assert all(isinstance(file, FileInfo) for file in recent_files)
+        assert all(isinstance(file, FileInfo) for file in recent_files_int)
+        assert all(isinstance(file, FileInfo) for file in recent_files_dt)
         assert len(all_files) == 1
-        assert len(recent_files) == 0
+        assert len(recent_files_int) == 0
+        assert len(recent_files_dt) == 0
         assert all_files[0].file_name == "foo.mrc"
         assert all_files[0].file_mtime == 1704070800
         assert all_files[0].file_size == 140401
@@ -240,7 +246,8 @@ class TestMockClient:
         assert all_files[0].file_uid == uid_gid
         assert all_files[0].file_gid == uid_gid
         assert all_files[0].file_atime is None
-        assert recent_files == []
+        assert recent_files_int == []
+        assert recent_files_dt == []
 
     def test_Client_list_sftp_file_not_found(self, mock_file_error, stub_creds):
         (

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -111,7 +111,7 @@ class TestMockClient:
             stub_creds["name"],
         ) = (port, "testdir", "test")
         connect = Client(**stub_creds)
-        file_exists = connect.file_exists(file="foo.mrc", dir="bar", remote=False)
+        file_exists = connect.file_exists(file_name="foo.mrc", dir="bar", remote=False)
         assert file_exists is True
 
     @pytest.mark.parametrize(
@@ -127,7 +127,7 @@ class TestMockClient:
             stub_creds["name"],
         ) = (port, "testdir", "test")
         connect = Client(**stub_creds)
-        file_exists = connect.file_exists(file="foo.mrc", dir="bar", remote=True)
+        file_exists = connect.file_exists(file_name="foo.mrc", dir="bar", remote=True)
         assert file_exists is True
 
     def test_Client_file_exists_sftp_file_not_found(self, mock_file_error, stub_creds):
@@ -137,7 +137,7 @@ class TestMockClient:
             stub_creds["name"],
         ) = (22, "testdir", "test")
         connect = Client(**stub_creds)
-        file_exists = connect.file_exists(file="foo.mrc", dir="bar", remote=True)
+        file_exists = connect.file_exists(file_name="foo.mrc", dir="bar", remote=True)
         assert file_exists is False
 
     @pytest.mark.parametrize(
@@ -206,7 +206,7 @@ class TestMockClient:
             stub_creds["name"],
         ) = (port, "testdir", "test")
         connect = Client(**stub_creds)
-        file = connect.get_file_info(file="foo.mrc", remote_dir=dir)
+        file = connect.get_file_info(file_name="foo.mrc", remote_dir=dir)
         assert isinstance(file, FileInfo)
         assert file.file_name == "foo.mrc"
         assert file.file_mtime == 1704070800
@@ -224,7 +224,7 @@ class TestMockClient:
         ) = (21, "testdir", "test")
         connect = Client(**stub_creds)
         with pytest.raises(ftplib.error_perm):
-            connect.get_file_info(file="foo.mrc", remote_dir="testdir")
+            connect.get_file_info(file_name="foo.mrc", remote_dir="testdir")
 
     def test_Client_sftp_get_file_info_not_found(self, mock_file_error, stub_creds):
         (
@@ -234,7 +234,7 @@ class TestMockClient:
         ) = (22, "testdir", "test")
         connect = Client(**stub_creds)
         with pytest.raises(OSError):
-            connect.get_file_info(file="foo.mrc", remote_dir="testdir")
+            connect.get_file_info(file_name="foo.mrc", remote_dir="testdir")
 
     @pytest.mark.parametrize("port, uid_gid", [(21, None), (22, 0)])
     def test_Client_list_file_info(self, mock_Client, stub_creds, port, uid_gid):

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -331,7 +331,7 @@ class TestMockClient:
         mock_file_info.file_stream = io.BytesIO(b"0")
         connect.put_file(file=mock_file_info, dir="bar", remote=remote, check=True)
         assert (
-            f"Skipping {mock_file_info.file_name}. File already exists in bar."
+            f"Skipping {mock_file_info.file_name}. File already exists in `bar`."
             in caplog.text
         )
 

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -44,7 +44,7 @@ def test_FileInfo_from_stat_data(mock_sftp_attr):
     assert baz.file_mode == 33279
 
 
-def test_FileInfo_from_stat_data_no_filename(mock_sftp_attr):
+def test_FileInfo_from_stat_data_no_file_name(mock_sftp_attr):
     sftp_attr = mock_sftp_attr
     sftp_attr.filename = None
     with pytest.raises(AttributeError) as exc:
@@ -52,7 +52,15 @@ def test_FileInfo_from_stat_data_no_filename(mock_sftp_attr):
     assert "No filename provided" in str(exc)
 
 
-def test_FileInfo_from_stat_data_st_mtime_error(mock_sftp_attr):
+def test_FileInfo_from_stat_data_no_file_size(mock_sftp_attr):
+    sftp_attr = mock_sftp_attr
+    sftp_attr.st_size = None
+    with pytest.raises(AttributeError) as exc:
+        FileInfo.from_stat_data(data=sftp_attr)
+    assert "No file size provided" in str(exc)
+
+
+def test_FileInfo_from_stat_data_no_file_mtime(mock_sftp_attr):
     sftp_attr = mock_sftp_attr
     delattr(sftp_attr, "st_mtime")
     with pytest.raises(AttributeError) as exc:
@@ -60,7 +68,7 @@ def test_FileInfo_from_stat_data_st_mtime_error(mock_sftp_attr):
     assert "No file modification time provided" in str(exc)
 
 
-def test_FileInfo_from_stat_data_st_mode_error(mock_sftp_attr):
+def test_FileInfo_from_stat_data_no_file_mode(mock_sftp_attr):
     sftp_attr = mock_sftp_attr
     sftp_attr.st_mode = None
     with pytest.raises(AttributeError) as exc:

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -1,30 +1,30 @@
 import os
 import paramiko
 import pytest
-from file_retriever.file import File
+from file_retriever.file import FileInfo
 
 
-def test_File():
-    file = File(file_name="foo.mrc", file_mtime=1704070800)
+def test_FileInfo():
+    file = FileInfo(file_name="foo.mrc", file_mtime=1704070800)
     assert file.file_name == "foo.mrc"
     assert file.file_mtime == 1704070800
     assert isinstance(file.file_name, str)
     assert isinstance(file.file_mtime, int)
-    assert isinstance(file, File)
+    assert isinstance(file, FileInfo)
 
 
 def test_File_from_stat_data(mock_ftpClient_sftpClient):
     foo_attr = paramiko.SFTPAttributes.from_stat(
         obj=os.stat("foo.mrc"), filename="foo.mrc"
     )
-    foo = File.from_stat_data(data=foo_attr)
+    foo = FileInfo.from_stat_data(data=foo_attr)
     bar_attr = paramiko.SFTPAttributes.from_stat(obj=os.stat("bar.mrc"))
-    bar = File.from_stat_data(data=bar_attr, file_name="bar.mrc")
+    bar = FileInfo.from_stat_data(data=bar_attr, file_name="bar.mrc")
     baz_attr = paramiko.SFTPAttributes.from_stat(obj=os.stat("baz.mrc"))
     baz_attr.longname = (
         "-rw-r--r--    1 0        0          140401 Jan  1 00:01 baz.mrc"
     )
-    baz = File.from_stat_data(data=baz_attr)
+    baz = FileInfo.from_stat_data(data=baz_attr)
     assert isinstance(foo_attr, paramiko.SFTPAttributes)
     assert foo.file_name == "foo.mrc"
     assert foo.file_mtime == 1704070800
@@ -39,7 +39,7 @@ def test_File_from_stat_data(mock_ftpClient_sftpClient):
 def test_File_from_stat_data_no_filename(mock_ftpClient_sftpClient):
     sftp_attr = paramiko.SFTPAttributes.from_stat(obj=os.stat("foo.mrc"))
     with pytest.raises(AttributeError) as exc:
-        File.from_stat_data(data=sftp_attr)
+        FileInfo.from_stat_data(data=sftp_attr)
     assert "No filename provided" in str(exc)
 
 
@@ -49,7 +49,7 @@ def test_File_from_stat_data_no_st_mtime(mock_ftpClient_sftpClient):
     )
     delattr(sftp_attr, "st_mtime")
     with pytest.raises(AttributeError) as exc:
-        File.from_stat_data(data=sftp_attr)
+        FileInfo.from_stat_data(data=sftp_attr)
     assert "No file modification time provided" in str(exc)
 
 
@@ -59,7 +59,7 @@ def test_File_from_stat_data_None_st_mtime(mock_ftpClient_sftpClient):
     )
     sftp_attr.st_mtime = None
     with pytest.raises(AttributeError) as exc:
-        File.from_stat_data(data=sftp_attr)
+        FileInfo.from_stat_data(data=sftp_attr)
     assert "No file modification time provided" in str(exc)
 
 
@@ -81,7 +81,7 @@ def test_File_from_stat_data_None_st_mtime(mock_ftpClient_sftpClient):
     ],
 )
 def test_File_parse_mdtm_time(str_time, mtime):
-    parsed = File.parse_mdtm_time(str_time)
+    parsed = FileInfo.parse_mdtm_time(str_time)
     assert parsed == mtime
 
 
@@ -100,8 +100,9 @@ def test_File_parse_mdtm_time(str_time, mtime):
             "-rxwrxwrxw",
             33279,
         ),
+        ("-r--------", 33024),
     ],
 )
 def test_File_parse_permissions(str_permissions, decimal_permissions):
-    parsed = File.parse_permissions(str_permissions)
+    parsed = FileInfo.parse_permissions(str_permissions)
     assert parsed == decimal_permissions

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -13,7 +13,7 @@ def test_File():
     assert isinstance(file, File)
 
 
-def test_File_from_stat_data(mock_file_data):
+def test_File_from_stat_data(mock_ftpClient_sftpClient):
     foo_attr = paramiko.SFTPAttributes.from_stat(
         obj=os.stat("foo.mrc"), filename="foo.mrc"
     )
@@ -36,14 +36,14 @@ def test_File_from_stat_data(mock_file_data):
     assert baz.file_name == "baz.mrc"
 
 
-def test_File_from_stat_data_no_filename(mock_file_data):
+def test_File_from_stat_data_no_filename(mock_ftpClient_sftpClient):
     sftp_attr = paramiko.SFTPAttributes.from_stat(obj=os.stat("foo.mrc"))
     with pytest.raises(AttributeError) as exc:
         File.from_stat_data(data=sftp_attr)
     assert "No filename provided" in str(exc)
 
 
-def test_File_from_stat_data_no_st_mtime(mock_file_data):
+def test_File_from_stat_data_no_st_mtime(mock_ftpClient_sftpClient):
     sftp_attr = paramiko.SFTPAttributes.from_stat(
         obj=os.stat("foo.mrc"), filename="foo.mrc"
     )
@@ -53,7 +53,7 @@ def test_File_from_stat_data_no_st_mtime(mock_file_data):
     assert "No file modification time provided" in str(exc)
 
 
-def test_File_from_stat_data_None_st_mtime(mock_file_data):
+def test_File_from_stat_data_None_st_mtime(mock_ftpClient_sftpClient):
     sftp_attr = paramiko.SFTPAttributes.from_stat(
         obj=os.stat("foo.mrc"), filename="foo.mrc"
     )

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -1,88 +1,91 @@
-import os
+import io
 import paramiko
 import pytest
-from file_retriever.file import FileInfo
+from file_retriever.file import FileInfo, File
 
 
 def test_FileInfo():
-    file = FileInfo(file_name="foo.mrc", file_mtime=1704070800)
+    file = FileInfo(file_name="foo.mrc", file_mtime=1704070800, file_mode="-rw-r--r--")
     assert file.file_name == "foo.mrc"
     assert file.file_mtime == 1704070800
+    assert file.file_mode == 33188
+    assert file.file_gid is None
+    assert file.file_uid is None
+    assert file.file_size is None
+    assert file.file_atime is None
     assert isinstance(file.file_name, str)
     assert isinstance(file.file_mtime, int)
     assert isinstance(file, FileInfo)
 
 
-def test_File_from_stat_data(mock_ftpClient_sftpClient):
-    foo_attr = paramiko.SFTPAttributes.from_stat(
-        obj=os.stat("foo.mrc"), filename="foo.mrc"
-    )
-    foo = FileInfo.from_stat_data(data=foo_attr)
-    bar_attr = paramiko.SFTPAttributes.from_stat(obj=os.stat("bar.mrc"))
+def test_FileInfo_from_stat_data(mock_sftp_attr):
+    foo = FileInfo.from_stat_data(data=mock_sftp_attr)
+    bar_attr = mock_sftp_attr
+    bar_attr.filename = None
     bar = FileInfo.from_stat_data(data=bar_attr, file_name="bar.mrc")
-    baz_attr = paramiko.SFTPAttributes.from_stat(obj=os.stat("baz.mrc"))
+    baz_attr = mock_sftp_attr
+    baz_attr.filename, baz_attr.st_mode = None, None
     baz_attr.longname = (
-        "-rw-r--r--    1 0        0          140401 Jan  1 00:01 baz.mrc"
+        "-rwxrwxrwx    1 0        0          140401 Jan  1 00:01 baz.mrc"
     )
     baz = FileInfo.from_stat_data(data=baz_attr)
-    assert isinstance(foo_attr, paramiko.SFTPAttributes)
+    assert isinstance(bar_attr, paramiko.SFTPAttributes)
+    assert isinstance(baz_attr, paramiko.SFTPAttributes)
     assert foo.file_name == "foo.mrc"
-    assert foo.file_mtime == 1704070800
-    assert foo.file_size == 140401
-    assert foo.file_uid == 0
-    assert foo.file_gid == 0
-    assert foo.file_mode == 33188
     assert bar.file_name == "bar.mrc"
     assert baz.file_name == "baz.mrc"
+    assert foo.file_mtime == 1704070800
+    assert bar.file_mtime == 1704070800
+    assert baz.file_mtime == 1704070800
+    assert foo.file_mode == 33188
+    assert bar.file_mode == 33188
+    assert baz.file_mode == 33279
 
 
-def test_File_from_stat_data_no_filename(mock_ftpClient_sftpClient):
-    sftp_attr = paramiko.SFTPAttributes.from_stat(obj=os.stat("foo.mrc"))
+def test_FileInfo_from_stat_data_no_filename(mock_sftp_attr):
+    sftp_attr = mock_sftp_attr
+    sftp_attr.filename = None
     with pytest.raises(AttributeError) as exc:
         FileInfo.from_stat_data(data=sftp_attr)
     assert "No filename provided" in str(exc)
 
 
-def test_File_from_stat_data_no_st_mtime(mock_ftpClient_sftpClient):
-    sftp_attr = paramiko.SFTPAttributes.from_stat(
-        obj=os.stat("foo.mrc"), filename="foo.mrc"
-    )
+def test_FileInfo_from_stat_data_st_mtime_error(mock_sftp_attr):
+    sftp_attr = mock_sftp_attr
     delattr(sftp_attr, "st_mtime")
     with pytest.raises(AttributeError) as exc:
         FileInfo.from_stat_data(data=sftp_attr)
     assert "No file modification time provided" in str(exc)
 
 
-def test_File_from_stat_data_None_st_mtime(mock_ftpClient_sftpClient):
-    sftp_attr = paramiko.SFTPAttributes.from_stat(
-        obj=os.stat("foo.mrc"), filename="foo.mrc"
-    )
-    sftp_attr.st_mtime = None
+def test_FileInfo_from_stat_data_st_mode_error(mock_sftp_attr):
+    sftp_attr = mock_sftp_attr
+    sftp_attr.st_mode = None
     with pytest.raises(AttributeError) as exc:
         FileInfo.from_stat_data(data=sftp_attr)
-    assert "No file modification time provided" in str(exc)
+    assert "No file mode provided" in str(exc)
 
 
 @pytest.mark.parametrize(
     "str_time, mtime",
     [
         (
-            "220 20240101010000",
+            "20240101010000",
             1704070800,
         ),
         (
-            "220 20240202020202",
+            "20240202020202",
             1706839322,
         ),
         (
-            "220 20240303030303",
+            "20240303030303",
             1709434983,
         ),
     ],
 )
-def test_File_parse_mdtm_time(str_time, mtime):
-    parsed = FileInfo.parse_mdtm_time(str_time)
-    assert parsed == mtime
+def test_FileInfo_parse_mdtm_time(str_time, mtime):
+    file = FileInfo(file_name="foo.mrc", file_mtime=str_time, file_mode=33188)
+    assert file.file_mtime == mtime
 
 
 @pytest.mark.parametrize(
@@ -103,6 +106,55 @@ def test_File_parse_mdtm_time(str_time, mtime):
         ("-r--------", 33024),
     ],
 )
-def test_File_parse_permissions(str_permissions, decimal_permissions):
-    parsed = FileInfo.parse_permissions(str_permissions)
-    assert parsed == decimal_permissions
+def test_FileInfo_parse_permissions(str_permissions, decimal_permissions):
+    file = FileInfo(
+        file_name="foo.mrc", file_mtime=1704070800, file_mode=str_permissions
+    )
+    assert file.file_mode == decimal_permissions
+
+
+def test_File():
+    foo = File(
+        file_name="foo.mrc",
+        file_mtime=1704070800,
+        file_size=1,
+        file_uid=None,
+        file_gid=None,
+        file_atime=None,
+        file_mode="-rw-r--r--",
+        file_stream=io.BytesIO(b"foo"),
+    )
+    bar = File(
+        file_name="bar.txt",
+        file_mtime="20240101010000",
+        file_size=1,
+        file_uid=0,
+        file_gid=0,
+        file_atime=None,
+        file_mode="-rw-r--r--",
+        file_stream=io.BytesIO(b"foo"),
+    )
+    assert foo.file_name == "foo.mrc"
+    assert foo.file_mtime == 1704070800
+    assert bar.file_name == "bar.txt"
+    assert bar.file_mtime == 1704070800
+    assert isinstance(foo.file_name, str)
+    assert isinstance(foo.file_mtime, int)
+    assert isinstance(bar.file_name, str)
+    assert isinstance(bar.file_mtime, int)
+    assert isinstance(foo, FileInfo)
+    assert isinstance(foo, File)
+    assert isinstance(bar, FileInfo)
+    assert isinstance(bar, File)
+
+
+def test_File_from_fileinfo(mock_file_info):
+    file = File.from_fileinfo(
+        file=mock_file_info,
+        file_stream=io.BytesIO(b"foo"),
+    )
+    assert file.file_name == "foo.mrc"
+    assert file.file_mtime == 1704070800
+    assert isinstance(file.file_name, str)
+    assert isinstance(file.file_mtime, int)
+    assert isinstance(file, FileInfo)

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -5,13 +5,15 @@ from file_retriever.file import FileInfo, File
 
 
 def test_FileInfo():
-    file = FileInfo(file_name="foo.mrc", file_mtime=1704070800, file_mode="-rw-r--r--")
+    file = FileInfo(
+        file_name="foo.mrc", file_mtime=1704070800, file_mode="-rw-r--r--", file_size=1
+    )
     assert file.file_name == "foo.mrc"
     assert file.file_mtime == 1704070800
     assert file.file_mode == 33188
+    assert file.file_size == 1
     assert file.file_gid is None
     assert file.file_uid is None
-    assert file.file_size is None
     assert file.file_atime is None
     assert isinstance(file.file_name, str)
     assert isinstance(file.file_mtime, int)
@@ -84,7 +86,9 @@ def test_FileInfo_from_stat_data_st_mode_error(mock_sftp_attr):
     ],
 )
 def test_FileInfo_parse_mdtm_time(str_time, mtime):
-    file = FileInfo(file_name="foo.mrc", file_mtime=str_time, file_mode=33188)
+    file = FileInfo(
+        file_name="foo.mrc", file_mtime=str_time, file_mode=33188, file_size=1
+    )
     assert file.file_mtime == mtime
 
 
@@ -108,7 +112,10 @@ def test_FileInfo_parse_mdtm_time(str_time, mtime):
 )
 def test_FileInfo_parse_permissions(str_permissions, decimal_permissions):
     file = FileInfo(
-        file_name="foo.mrc", file_mtime=1704070800, file_mode=str_permissions
+        file_name="foo.mrc",
+        file_mtime=1704070800,
+        file_mode=str_permissions,
+        file_size=1,
     )
     assert file.file_mode == decimal_permissions
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,7 @@ import logging
 import logging.config
 import os
 import pytest
-from file_retriever.utils import logger_config, vendor_config
+from file_retriever.utils import logger_config, client_config
 
 
 def test_logger_config():
@@ -49,8 +49,9 @@ def test_vendor_config(mocker):
     m = mocker.mock_open(read_data=yaml_string)
     mocker.patch("builtins.open", m)
 
-    vendor_config("foo.yaml")
-
+    client_list = client_config("foo.yaml")
+    assert len(client_list) == 1
+    assert client_list == ["TEST"]
     assert os.environ["TEST_HOST"] == "foo"
     assert os.environ["TEST_USER"] == "bar"
     assert os.environ["TEST_PASSWORD"] == "baz"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -40,20 +40,25 @@ def test_logger_config_stream(message, level, caplog):
 
 def test_vendor_config(mocker):
     yaml_string = """
-        TEST_HOST: foo
-        TEST_USER: bar
-        TEST_PASSWORD: baz
-        TEST_PORT: '22'
-        TEST_SRC: test_src
+        FOO_HOST: foo
+        FOO_USER: bar
+        FOO_PASSWORD: baz
+        FOO_PORT: '21'
+        FOO_SRC: foo_src
+        BAR_HOST: foo
+        BAR_USER: bar
+        BAR_PASSWORD: baz
+        BAR_PORT: '22'
+        BAR_SRC: bar_src
     """
     m = mocker.mock_open(read_data=yaml_string)
     mocker.patch("builtins.open", m)
 
     client_list = client_config("foo.yaml")
-    assert len(client_list) == 1
-    assert client_list == ["TEST"]
-    assert os.environ["TEST_HOST"] == "foo"
-    assert os.environ["TEST_USER"] == "bar"
-    assert os.environ["TEST_PASSWORD"] == "baz"
-    assert os.environ["TEST_PORT"] == "22"
-    assert os.environ["TEST_SRC"] == "test_src"
+    assert len(client_list) == 2
+    assert client_list == ["FOO", "BAR"]
+    assert os.environ["FOO_HOST"] == "foo"
+    assert os.environ["FOO_USER"] == "bar"
+    assert os.environ["FOO_PASSWORD"] == "baz"
+    assert os.environ["FOO_PORT"] == "21"
+    assert os.environ["FOO_SRC"] == "foo_src"


### PR DESCRIPTION
Changed:
 + `File` dataclass changed to `FileInfo` class
 + `parse_permissions` and `parse_mdtm_time` changed from static methods to private methods of `FileInfo` class
 + `file_size` is now a required attribute of `File` and `FileInfo` classes
 + `vendor_config` function -> `client_config` in `utils.py`. Function now returns a list of servers whose credentials have been added to env vars
 + renamed methods in `_ftpClient` and `_sftpClient` classes
    + `download_file` -> `fetch_file` 
    + `upload_file` -> `write_file`
    + `list_remote_file_data` -> `list_file_data`
    + `get_remote_file_data` -> `get_file_data`
 + `_ftpClient`, `_sftpClient`, and `Client` classes now raise custom exceptions
 + `fetch_file` method in `_ftpClient` and `_sftpClient` now takes a `FileInfo` object as the type for the `file` arg and returns a `File` object containing the metadata and content of the file
 + clarified names for args in `_ftpClient`, `_sftpClient`, and `Client` methods:
    + `file` is used as name of arg if arg is a `FileInfo` or `File` object
    + `file_name` is used as name of arg if arg is a str representing the name of a file
    + `dir` is used as name of arg if arg refers to a directory on either remote or local storage
    + `remote_dir` is used as name of arg if refers to a directory on remote storage
 + `write_file` method of `_ftpClient` and `_sftpClient` now takes `remote` arg to specify if file should be written to a local or remote directory
 + clarified when to record log messages and what data to include:
    + INFO and DEBUG log messages are now only recorded in methods of `Client` class
    + ERROR log messages are recorded in methods of `_ftpClient` and `_sftpClient` classes except for `get_file_data` method
    + errors raised by `get_file_data` method of `_ftpClient` and `_sftpClient` classes are logged when the method is called using the `Client.get_file_info` method but not when it is called by the `Client.file_exists` method (in order to avoid logging errors when files are not found before writing a file to a directory)
    + INFO and DEBUG messages contain name of server at beginning of message to make logs clearer when connected to multiple clients
 + `Client` `vendor` attribute changed to `name` as it will be used by both vendor clients and NSDROP
 + renamed methods in `Client` class:
    + `get_file_data` -> `get_file_info` 
    + `list_files_in_dir` -> `list_file_info`
    + `check_file` -> `file_exists`
 + changed args and names of args within `Client` methods
    + `remote_dir` is now Optional when used. `self.remote_dir` attribute is used when a value is not passed to a method that takes `remote_dir` arg
    + `time_delta` arg of `Client.list_file_info` method can now be passed either the number of days as an `int` or a `datetime.timedelta` object
 + `Client.put_file` now has an optional return type. If the file already exists in the directory where it is to be written, the method returns `None`
 + refactored tests

Added:
 + `FileRetrieverError`, `RetrieverAuthenticationError`, `RetrieverConnectionError` and `RetrieverFileError` exceptions
 + `File` class (subclassed from `FileInfo`) which now includes `file_stream` to store content of file as `io.BytesIO` object
 + docstrings to any modules, classes, or methods that did not have them before
 + `_check_dir` method to `_ftpClient` and `_sftpClient` classes in order to ensure files are being fetched from or written to the correct directory
 + `close` method to `Client` class to manually close a connection (rather than just rely on context manager to close connections)
 + additional tests

Removed:
 + routines handling `ftplib.error_reply` messages as they are likely rare and do not need to be handled separately 