### PR TITLE
simplified conftest and removed unused fixtures

### DIFF
--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -1,5 +1,4 @@
 from contextlib import nullcontext as does_not_raise
-import datetime
 import io
 import os
 import pytest
@@ -28,61 +27,59 @@ def test_BaseClient(mock_file_info):
 class TestMock_ftpClient:
     """Test the _ftpClient class with mock responses."""
 
-    def test_ftpClient(self, stub_client, stub_creds):
+    def test_ftpClient(self, mock_login, stub_creds):
         stub_creds["port"] = "21"
         ftp = _ftpClient(**stub_creds)
         assert ftp.connection is not None
 
-    def test_ftpClient_no_creds(self, stub_client):
+    def test_ftpClient_no_creds(self, mock_login):
         creds = {}
         with pytest.raises(TypeError):
             _ftpClient(**creds)
 
-    def test_ftpClient_error_perm(self, mock_auth_error, stub_creds):
+    def test_ftpClient_auth_error(self, mock_Client_auth_error, stub_creds):
         stub_creds["port"] = "21"
         with pytest.raises(RetrieverAuthenticationError):
             _ftpClient(**stub_creds)
 
-    def test_ftpClient_error_temp(self, mock_login_connection_error, stub_creds):
+    def test_ftpClient_connection_error(self, mock_Client_connection_error, stub_creds):
         stub_creds["port"] = "21"
         with pytest.raises(RetrieverConnectionError):
             _ftpClient(**stub_creds)
 
-    def test_ftpClient_check_dir(self, mock_ftpClient_sftpClient, stub_creds):
+    def test_ftpClient_check_dir(self, mock_Client, stub_creds):
         stub_creds["port"] = "21"
         ftp = _ftpClient(**stub_creds)
         with does_not_raise():
             ftp._check_dir(dir="foo")
 
-    def test_ftpClient_check_dir_cwd(self, mock_cwd, stub_creds):
+    def test_ftpClient_check_dir_cwd(self, mock_Client_in_cwd, stub_creds):
         stub_creds["port"] = "21"
         ftp = _ftpClient(**stub_creds)
         with does_not_raise():
             ftp._check_dir(dir="/")
 
-    def test_ftpClient_close(self, mock_ftpClient_sftpClient, stub_creds):
+    def test_ftpClient_close(self, mock_Client, stub_creds):
         stub_creds["port"] = "21"
         ftp = _ftpClient(**stub_creds)
         connection = ftp.close()
         assert connection is None
 
-    def test_ftpClient_fetch_file(
-        self, mock_ftpClient_sftpClient, mock_file_info, stub_creds
-    ):
+    def test_ftpClient_fetch_file(self, mock_Client, mock_file_info, stub_creds):
         stub_creds["port"] = "21"
         ftp = _ftpClient(**stub_creds)
         fh = ftp.fetch_file(file=mock_file_info, dir="bar")
         assert fh.file_stream.getvalue()[0:1] == b"0"
 
-    def test_ftpClient_fetch_file_permissions_error(
-        self, mock_file_info, mock_file_error, stub_creds
+    def test_ftpClient_fetch_file_error(
+        self, mock_file_error, mock_file_info, stub_creds
     ):
         stub_creds["port"] = "21"
         with pytest.raises(RetrieverFileError):
             ftp = _ftpClient(**stub_creds)
             ftp.fetch_file(file=mock_file_info, dir="bar")
 
-    def test_ftpClient_get_file_data(self, mock_ftpClient_sftpClient, stub_creds):
+    def test_ftpClient_get_file_data(self, mock_Client, stub_creds):
         stub_creds["port"] = "21"
         ftp = _ftpClient(**stub_creds)
         file_data = ftp.get_file_data(file_name="foo.mrc", dir="testdir")
@@ -94,21 +91,21 @@ class TestMock_ftpClient:
         assert file_data.file_gid is None
         assert file_data.file_atime is None
 
-    def test_ftpClient_get_file_data_error_perm(self, mock_file_error, stub_creds):
+    def test_ftpClient_get_file_data_error(self, mock_file_error, stub_creds):
         stub_creds["port"] = "21"
         ftp = _ftpClient(**stub_creds)
         with pytest.raises(RetrieverFileError):
             ftp.get_file_data(file_name="foo.mrc", dir="testdir")
 
-    def test_ftpClient_get_file_data_file_not_found(
-        self, mock_ftp_file_not_found, stub_creds
+    def test_ftpClient_get_file_data_none_type_return(
+        self, mock_file_none_type_return, stub_creds
     ):
         stub_creds["port"] = "21"
         ftp = _ftpClient(**stub_creds)
         with pytest.raises(RetrieverFileError):
             ftp.get_file_data(file_name="foo.mrc", dir="testdir")
 
-    def test_ftpClient_list_file_data(self, mock_ftpClient_sftpClient, stub_creds):
+    def test_ftpClient_list_file_data(self, mock_Client, stub_creds):
         stub_creds["port"] = "21"
         ftp = _ftpClient(**stub_creds)
         files = ftp.list_file_data(dir="testdir")
@@ -122,27 +119,27 @@ class TestMock_ftpClient:
         assert files[0].file_gid is None
         assert files[0].file_atime is None
 
-    def test_ftpClient_list_file_data_error_perm(self, mock_file_error, stub_creds):
+    def test_ftpClient_list_file_data_error(self, mock_file_error, stub_creds):
         stub_creds["port"] = "21"
         ftp = _ftpClient(**stub_creds)
         with pytest.raises(RetrieverFileError):
             ftp.list_file_data(dir="testdir")
 
-    def test_ftpClient_is_active_true(self, mock_ftpClient_sftpClient, stub_creds):
+    def test_ftpClient_is_active_true(self, mock_Client, stub_creds):
         stub_creds["port"] = "21"
         ftp = _ftpClient(**stub_creds)
         live_connection = ftp.is_active()
         assert live_connection is True
 
-    def test_ftpClient_is_active_false(self, mock_connection_dropped, stub_creds):
+    def test_ftpClient_is_active_false(
+        self, mock_Client_connection_dropped, stub_creds
+    ):
         stub_creds["port"] = "21"
         ftp = _ftpClient(**stub_creds)
         live_connection = ftp.is_active()
         assert live_connection is False
 
-    def test_ftpClient_write_file(
-        self, mock_ftpClient_sftpClient, mock_file_info, stub_creds
-    ):
+    def test_ftpClient_write_file(self, mock_Client, mock_file_info, stub_creds):
         stub_creds["port"] = "21"
         ftp = _ftpClient(**stub_creds)
         assert mock_file_info.file_name == "foo.mrc"
@@ -164,7 +161,7 @@ class TestMock_ftpClient:
             ftp.write_file(file=mock_file_info, dir="bar", remote=False)
         assert "'FileInfo' object has no attribute 'file_stream'" in str(exc.value)
 
-    def test_ftpClient_write_file_local_not_found(
+    def test_ftpClient_write_file_local_error(
         self, mock_file_error, mock_file_info, stub_creds
     ):
         stub_creds["port"] = "21"
@@ -173,7 +170,7 @@ class TestMock_ftpClient:
         with pytest.raises(RetrieverFileError):
             ftp.write_file(file=file, dir="bar", remote=False)
 
-    def test_ftpClient_write_file_remote_not_found(
+    def test_ftpClient_write_file_remote_error(
         self, mock_file_error, mock_file_info, stub_creds
     ):
         stub_creds["port"] = "21"
@@ -186,67 +183,67 @@ class TestMock_ftpClient:
 class TestMock_sftpClient:
     """Test the _sftpClient class with mock responses."""
 
-    def test_sftpClient(self, stub_client, stub_creds):
+    def test_sftpClient(self, mock_login, stub_creds):
         stub_creds["port"] = "22"
         sftp = _sftpClient(**stub_creds)
         assert sftp.connection is not None
 
-    def test_sftpClient_no_creds(self, stub_client):
+    def test_sftpClient_no_creds(self, mock_login):
         creds = {}
         with pytest.raises(TypeError):
             _sftpClient(**creds)
 
-    def test_sftpClient_auth_error(self, mock_auth_error, stub_creds):
+    def test_sftpClient_auth_error(self, mock_Client_auth_error, stub_creds):
         stub_creds["port"] = "22"
         with pytest.raises(RetrieverAuthenticationError):
             _sftpClient(**stub_creds)
 
-    def test_sftpclient_SSHException(self, mock_login_connection_error, stub_creds):
+    def test_sftpClient_connection_error(
+        self, mock_Client_connection_error, stub_creds
+    ):
         stub_creds["port"] = "22"
         with pytest.raises(RetrieverConnectionError):
             _sftpClient(**stub_creds)
 
-    def test_sftpClient_check_dir(self, mock_ftpClient_sftpClient, stub_creds):
+    def test_sftpClient_check_dir(self, mock_Client, stub_creds):
         stub_creds["port"] = "22"
         sftp = _sftpClient(**stub_creds)
         with does_not_raise():
             sftp._check_dir(dir="foo")
 
-    def test_sftpClient_check_dir_cwd(self, mock_cwd, stub_creds):
+    def test_sftpClient_check_dir_cwd(self, mock_Client_in_cwd, stub_creds):
         stub_creds["port"] = "22"
         sftp = _sftpClient(**stub_creds)
         with does_not_raise():
             sftp._check_dir(dir="/")
 
-    def test_sftpClient_check_dir_other_dir(self, mock_other_dir, stub_creds):
+    def test_sftpClient_check_dir_other_dir(self, mock_Client_in_other_dir, stub_creds):
         stub_creds["port"] = "22"
         sftp = _sftpClient(**stub_creds)
         with does_not_raise():
             sftp._check_dir(dir="foo")
 
-    def test_sftpClient_close(self, mock_ftpClient_sftpClient, stub_creds):
+    def test_sftpClient_close(self, mock_Client, stub_creds):
         stub_creds["port"] = "22"
         sftp = _sftpClient(**stub_creds)
         connection = sftp.close()
         assert connection is None
 
-    def test_sftpClient_fetch_file(
-        self, mock_ftpClient_sftpClient, mock_file_info, stub_creds
-    ):
+    def test_sftpClient_fetch_file(self, mock_Client, mock_file_info, stub_creds):
         stub_creds["port"] = "22"
         sftp = _sftpClient(**stub_creds)
         fh = sftp.fetch_file(file=mock_file_info, dir="bar")
         assert fh.file_stream.getvalue()[0:1] == b"0"
 
-    def test_sftpClient_fetch_file_not_found(
-        self, mock_file_info, mock_file_error, stub_creds
+    def test_sftpClient_fetch_file_error(
+        self, mock_file_error, mock_file_info, stub_creds
     ):
         stub_creds["port"] = "22"
         sftp = _sftpClient(**stub_creds)
         with pytest.raises(RetrieverFileError):
             sftp.fetch_file(file=mock_file_info, dir="bar")
 
-    def test_sftpClient_get_file_data(self, mock_ftpClient_sftpClient, stub_creds):
+    def test_sftpClient_get_file_data(self, mock_Client, stub_creds):
         stub_creds["port"] = "22"
         ftp = _sftpClient(**stub_creds)
         file_data = ftp.get_file_data(file_name="foo.mrc", dir="testdir")
@@ -258,13 +255,13 @@ class TestMock_sftpClient:
         assert file_data.file_gid == 0
         assert file_data.file_atime is None
 
-    def test_sftpClient_get_file_data_not_found(self, mock_file_error, stub_creds):
+    def test_sftpClient_get_file_data_error(self, mock_file_error, stub_creds):
         stub_creds["port"] = "22"
         sftp = _sftpClient(**stub_creds)
         with pytest.raises(RetrieverFileError):
             sftp.get_file_data(file_name="foo.mrc", dir="testdir")
 
-    def test_sftpClient_list_file_data(self, mock_ftpClient_sftpClient, stub_creds):
+    def test_sftpClient_list_file_data(self, mock_Client, stub_creds):
         stub_creds["port"] = "22"
         ftp = _sftpClient(**stub_creds)
         files = ftp.list_file_data(dir="testdir")
@@ -278,27 +275,27 @@ class TestMock_sftpClient:
         assert files[0].file_gid == 0
         assert files[0].file_atime is None
 
-    def test_sftpClient_list_file_data_not_found(self, mock_file_error, stub_creds):
+    def test_sftpClient_list_file_data_error(self, mock_file_error, stub_creds):
         stub_creds["port"] = "22"
         sftp = _sftpClient(**stub_creds)
         with pytest.raises(RetrieverFileError):
             sftp.list_file_data(dir="testdir")
 
-    def test_sftpClient_is_active_true(self, mock_ftpClient_sftpClient, stub_creds):
+    def test_sftpClient_is_active_true(self, mock_Client, stub_creds):
         stub_creds["port"] = "22"
         sftp = _sftpClient(**stub_creds)
         live_connection = sftp.is_active()
         assert live_connection is True
 
-    def test_sftpClient_is_active_false(self, mock_connection_dropped, stub_creds):
+    def test_sftpClient_is_active_false(
+        self, mock_Client_connection_dropped, stub_creds
+    ):
         stub_creds["port"] = "22"
         sftp = _sftpClient(**stub_creds)
         live_connection = sftp.is_active()
         assert live_connection is False
 
-    def test_sftpClient_write_file(
-        self, mock_ftpClient_sftpClient, mock_file_info, stub_creds
-    ):
+    def test_sftpClient_write_file(self, mock_Client, mock_file_info, stub_creds):
         stub_creds["port"] = "22"
         sftp = _sftpClient(**stub_creds)
         file_obj = File.from_fileinfo(file=mock_file_info, file_stream=io.BytesIO(b"0"))
@@ -307,20 +304,16 @@ class TestMock_sftpClient:
         assert remote_file.file_mtime == 1704070800
         assert local_file.file_mtime == 1704070800
 
-    def test_sftpClient_write_file_not_found_remote(
-        self, mock_file_error, mock_file_info, stub_creds, caplog
+    def test_sftpClient_write_file_no_file_stream(
+        self, mock_file_error, mock_file_info, stub_creds
     ):
         stub_creds["port"] = "22"
         sftp = _sftpClient(**stub_creds)
-        file_obj = File.from_fileinfo(file=mock_file_info, file_stream=io.BytesIO(b"0"))
-        with pytest.raises(RetrieverFileError):
-            sftp.write_file(file=file_obj, dir="bar", remote=True)
-        assert (
-            f"Unable to write {mock_file_info.file_name} to remote directory"
-            in caplog.text
-        )
+        with pytest.raises(AttributeError) as exc:
+            sftp.write_file(file=mock_file_info, dir="bar", remote=False)
+        assert "'FileInfo' object has no attribute 'file_stream'" in str(exc.value)
 
-    def test_sftpClient_write_file_not_found_local(
+    def test_sftpClient_write_file_local_error(
         self, mock_file_error, mock_file_info, stub_creds, caplog
     ):
         stub_creds["port"] = "22"
@@ -333,37 +326,37 @@ class TestMock_sftpClient:
             in caplog.text
         )
 
-    def test_sftpClient_write_file_no_file_stream(
-        self, mock_file_error, mock_file_info, stub_creds
+    def test_sftpClient_write_file_remote_error(
+        self, mock_file_error, mock_file_info, stub_creds, caplog
     ):
         stub_creds["port"] = "22"
         sftp = _sftpClient(**stub_creds)
-        with pytest.raises(AttributeError) as exc:
-            sftp.write_file(file=mock_file_info, dir="bar", remote=False)
-        assert "'FileInfo' object has no attribute 'file_stream'" in str(exc.value)
+        file_obj = File.from_fileinfo(file=mock_file_info, file_stream=io.BytesIO(b"0"))
+        with pytest.raises(RetrieverFileError):
+            sftp.write_file(file=file_obj, dir="bar", remote=True)
+        assert (
+            f"Unable to write {mock_file_info.file_name} to remote directory"
+            in caplog.text
+        )
 
 
 @pytest.mark.livetest
 class TestLiveClients:
     def test_ftpClient_live_test(self, live_creds):
-        vendor = "LEILA"
-        remote_dir = os.environ[f"{vendor}_SRC"]
+        remote_dir = os.environ["LEILA_SRC"]
         live_ftp = _ftpClient(
-            username=os.environ[f"{vendor}_USER"],
-            password=os.environ[f"{vendor}_PASSWORD"],
-            host=os.environ[f"{vendor}_HOST"],
-            port=os.environ[f"{vendor}_PORT"],
+            username=os.environ["LEILA_USER"],
+            password=os.environ["LEILA_PASSWORD"],
+            host=os.environ["LEILA_HOST"],
+            port=os.environ["LEILA_PORT"],
         )
         file_list = live_ftp.list_file_data(dir=remote_dir)
-        file_names = [file.file_name for file in file_list]
         file_data = live_ftp.get_file_data(
             file_name="Sample_Full_RDA.mrc", dir=remote_dir
         )
         fetched_file = live_ftp.fetch_file(file_data, remote_dir)
-        assert "Sample_Full_RDA.mrc" in file_names
-        assert "220" in live_ftp.connection.getwelcome()
-        assert file_data.file_size == 7015
-        assert file_data.file_mode == 33188
+        assert len(file_list) > 1
+        assert file_data.file_size > 1
         assert fetched_file.file_stream.getvalue()[0:1] == b"0"
 
     def test_ftpClient_live_test_no_creds(self, stub_creds):
@@ -371,47 +364,44 @@ class TestLiveClients:
             stub_creds["port"] = "21"
             _ftpClient(**stub_creds)
 
-    def test_ftpClient_live_test_error_perm(self, live_creds):
-        vendor = "LEILA"
+    def test_ftpClient_live_test_auth_error(self, live_creds):
         with pytest.raises(RetrieverAuthenticationError):
             _ftpClient(
                 username="FOO",
-                password=os.environ[f"{vendor}_PASSWORD"],
-                host=os.environ[f"{vendor}_HOST"],
-                port=os.environ[f"{vendor}_PORT"],
+                password=os.environ["LEILA_PASSWORD"],
+                host=os.environ["LEILA_HOST"],
+                port=os.environ["LEILA_PORT"],
             )
 
     def test_sftpClient_live_test(self, live_creds):
-        vendor = "EASTVIEW"
-        remote_dir = os.environ[f"{vendor}_SRC"]
+        remote_dir = os.environ["EASTVIEW_SRC"]
         live_sftp = _sftpClient(
-            username=os.environ[f"{vendor}_USER"],
-            password=os.environ[f"{vendor}_PASSWORD"],
-            host=os.environ[f"{vendor}_HOST"],
-            port=os.environ[f"{vendor}_PORT"],
+            username=os.environ["EASTVIEW_USER"],
+            password=os.environ["EASTVIEW_PASSWORD"],
+            host=os.environ["EASTVIEW_HOST"],
+            port=os.environ["EASTVIEW_PORT"],
         )
         file_list = live_sftp.list_file_data(dir=remote_dir)
         file_data = live_sftp.get_file_data(
             file_name=file_list[0].file_name, dir=remote_dir
         )
         fetched_file = live_sftp.fetch_file(file=file_data, dir=remote_dir)
-        assert live_sftp.connection.get_channel().active == 1
-        assert datetime.datetime.fromtimestamp(
-            file_list[0].file_mtime
-        ) >= datetime.datetime(2020, 1, 1)
         assert len(file_list) > 1
         assert file_data.file_size > 1
-        assert file_data.file_mode > 32768
         assert fetched_file.file_stream.getvalue()[0:1] == b"0"
 
+    def test_sftpClient_live_test_no_creds(self, stub_creds):
+        stub_creds["port"] = "22"
+        with pytest.raises(OSError):
+            _sftpClient(**stub_creds)
+
     def test_sftpClient_live_test_auth_error(self, live_creds):
-        vendor = "EASTVIEW"
         with pytest.raises(RetrieverAuthenticationError):
             _sftpClient(
                 username="FOO",
-                password=os.environ[f"{vendor}_PASSWORD"],
-                host=os.environ[f"{vendor}_HOST"],
-                port=os.environ[f"{vendor}_PORT"],
+                password=os.environ["EASTVIEW_PASSWORD"],
+                host=os.environ["EASTVIEW_HOST"],
+                port=os.environ["EASTVIEW_PORT"],
             )
 
     def test_sftpClient_NSDROP(self, live_creds):

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -27,64 +27,45 @@ class TestMockClient:
             ),
         ],
     )
-    def test_Client(self, mock_Client, stub_creds, port, client_type):
-        (
-            stub_creds["port"],
-            stub_creds["name"],
-        ) = (port, "test")
-        connect = Client(**stub_creds)
+    def test_Client(self, mock_Client, stub_Client_creds, port, client_type):
+        stub_Client_creds["port"] = port
+        connect = Client(**stub_Client_creds)
         assert connect.name == "test"
         assert connect.host == "ftp.testvendor.com"
         assert connect.port == port
         assert isinstance(connect.session, client_type)
 
-    def test_Client_invalid_port(self, mock_Client, stub_creds):
-        (
-            stub_creds["port"],
-            stub_creds["name"],
-        ) = (1, "test")
+    def test_Client_invalid_port(self, mock_Client, stub_Client_creds):
+        stub_Client_creds["port"] = 1
         with pytest.raises(ValueError) as e:
-            Client(**stub_creds)
-        assert f"Invalid port number: {stub_creds['port']}" in str(e)
-
-    def test_Client_ftp_auth_error(self, mock_auth_error, stub_creds):
-        (
-            stub_creds["port"],
-            stub_creds["name"],
-        ) = (21, "test")
-        with pytest.raises(RetrieverAuthenticationError):
-            Client(**stub_creds)
-
-    def test_Client_sftp_auth_error(self, mock_auth_error, stub_creds):
-        (
-            stub_creds["port"],
-            stub_creds["name"],
-        ) = (22, "test")
-        with pytest.raises(RetrieverAuthenticationError):
-            Client(**stub_creds)
+            Client(**stub_Client_creds)
+        assert f"Invalid port number: {stub_Client_creds['port']}" in str(e)
 
     @pytest.mark.parametrize(
         "port",
         [21, 22],
     )
-    def test_Client_context_manager(self, mock_Client, stub_creds, port):
-        (
-            stub_creds["port"],
-            stub_creds["name"],
-        ) = (port, "test")
-        with Client(**stub_creds) as connect:
+    def test_Client_context_manager(self, mock_Client, stub_Client_creds, port):
+        stub_Client_creds["port"] = port
+        with Client(**stub_Client_creds) as connect:
             assert connect.session is not None
 
     @pytest.mark.parametrize(
         "port",
         [21, 22],
     )
-    def test_Client_check_connection(self, mock_Client, stub_creds, port):
-        (
-            stub_creds["port"],
-            stub_creds["name"],
-        ) = (port, "test")
-        connect = Client(**stub_creds)
+    def test_Client_auth_error(self, mock_Client_auth_error, stub_Client_creds, port):
+        stub_Client_creds["port"] = port
+        with pytest.raises(RetrieverAuthenticationError):
+            Client(**stub_Client_creds)
+
+    @pytest.mark.parametrize(
+        "port",
+        [21, 22],
+    )
+    def test_Client_check_connection_active(self, mock_Client, stub_Client_creds, port):
+        stub_Client_creds["port"] = port
+        connect = Client(**stub_Client_creds)
         live_connection = connect.check_connection()
         assert live_connection is True
 
@@ -92,34 +73,38 @@ class TestMockClient:
         "port",
         [21, 22],
     )
-    def test_Client_file_exists_true(
-        self, mock_Client_file_exists, stub_creds, port, mock_file_info
+    def test_Client_check_connection_inactive(
+        self, mock_Client_connection_dropped, stub_Client_creds, port
     ):
-        (
-            stub_creds["port"],
-            stub_creds["name"],
-        ) = (port, "test")
-        connect = Client(**stub_creds)
-        get_file = connect.get_file_info(file_name="foo.mrc", remote_dir="testdir")
+        stub_Client_creds["port"] = port
+        connect = Client(**stub_Client_creds)
+        live_connection = connect.check_connection()
+        assert live_connection is False
+
+    @pytest.mark.parametrize(
+        "port",
+        [21, 22],
+    )
+    def test_Client_file_exists_true(
+        self, mock_Client_file_exists, stub_Client_creds, port, mock_file_info
+    ):
+        stub_Client_creds["port"] = port
+        connect = Client(**stub_Client_creds)
         local_file_exists = connect.file_exists(
             file=mock_file_info, dir="bar", remote=False
         )
-        assert mock_file_info.file_name == get_file.file_name
-        assert mock_file_info.file_size == get_file.file_size
         remote_file_exists = connect.file_exists(
             file=mock_file_info, dir="bar", remote=True
         )
         assert local_file_exists is True
         assert remote_file_exists is True
 
-    def test_Client_file_exists_sftp_file_not_found(
-        self, mock_file_error, stub_creds, mock_file_info
+    @pytest.mark.parametrize("port", [21, 22])
+    def test_Client_file_exists_false(
+        self, mock_file_error, stub_Client_creds, mock_file_info, port
     ):
-        (
-            stub_creds["port"],
-            stub_creds["name"],
-        ) = (22, "test")
-        connect = Client(**stub_creds)
+        stub_Client_creds["port"] = port
+        connect = Client(**stub_Client_creds)
         file_exists = connect.file_exists(file=mock_file_info, dir="bar", remote=True)
         assert file_exists is False
 
@@ -127,85 +112,47 @@ class TestMockClient:
         "port",
         [21, 22],
     )
-    def test_Client_get_file(self, mock_Client, mock_file_info, stub_creds, port):
-        (
-            stub_creds["port"],
-            stub_creds["name"],
-        ) = (port, "test")
-        connect = Client(**stub_creds)
+    def test_Client_get_file(
+        self, mock_Client, mock_file_info, stub_Client_creds, port
+    ):
+        stub_Client_creds["port"] = port
+        connect = Client(**stub_Client_creds)
         file = File.from_fileinfo(file=mock_file_info, file_stream=io.BytesIO(b"0"))
         file = connect.get_file(file=file, remote_dir="testdir")
         assert isinstance(file, File)
+        assert file.file_stream is not None
 
-    def test_Client_ftp_get_file_error_perm(
-        self, mock_file_error, mock_file_info, stub_creds
+    @pytest.mark.parametrize("port", [21, 22])
+    def test_Client_get_file_error(
+        self, mock_file_error, mock_file_info, stub_Client_creds, port
     ):
-        (
-            stub_creds["port"],
-            stub_creds["name"],
-        ) = (21, "test")
-        connect = Client(**stub_creds)
+        stub_Client_creds["port"] = port
+        connect = Client(**stub_Client_creds)
         file_obj = File.from_fileinfo(file=mock_file_info, file_stream=io.BytesIO(b"0"))
         with pytest.raises(RetrieverFileError):
             connect.get_file(file=file_obj, remote_dir="bar_dir")
 
-    def test_Client_sftp_get_file_not_found(
-        self, mock_file_error, mock_file_info, stub_creds
-    ):
-        (
-            stub_creds["port"],
-            stub_creds["name"],
-        ) = (22, "test")
-        connect = Client(**stub_creds)
-        file_obj = File.from_fileinfo(file=mock_file_info, file_stream=io.BytesIO(b"0"))
-        with pytest.raises(RetrieverFileError):
-            connect.get_file(file=file_obj, remote_dir="bar_dir")
-
-    @pytest.mark.parametrize(
-        "port, uid_gid",
-        [(21, None), (22, 0)],
-    )
-    def test_Client_get_file_info(self, mock_Client, stub_creds, port, uid_gid):
-        (
-            stub_creds["port"],
-            stub_creds["name"],
-        ) = (port, "test")
-        connect = Client(**stub_creds)
+    @pytest.mark.parametrize("port", [21, 22])
+    def test_Client_get_file_info(self, mock_Client, stub_Client_creds, port):
+        stub_Client_creds["port"] = port
+        connect = Client(**stub_Client_creds)
         file = connect.get_file_info(file_name="foo.mrc", remote_dir="testdir")
         assert isinstance(file, FileInfo)
         assert file.file_name == "foo.mrc"
         assert file.file_mtime == 1704070800
-        assert file.file_size == 140401
-        assert file.file_mode == 33188
-        assert file.file_uid == uid_gid
-        assert file.file_gid == uid_gid
         assert file.file_atime is None
 
-    def test_Client_ftp_get_file_info_not_found(self, mock_file_error, stub_creds):
-        (
-            stub_creds["port"],
-            stub_creds["name"],
-        ) = (21, "test")
-        connect = Client(**stub_creds)
+    @pytest.mark.parametrize("port", [21, 22])
+    def test_Client_get_file_info_error(self, mock_file_error, stub_Client_creds, port):
+        stub_Client_creds["port"] = port
+        connect = Client(**stub_Client_creds)
         with pytest.raises(RetrieverFileError):
             connect.get_file_info(file_name="foo.mrc", remote_dir="testdir")
 
-    def test_Client_sftp_get_file_info_not_found(self, mock_file_error, stub_creds):
-        (
-            stub_creds["port"],
-            stub_creds["name"],
-        ) = (22, "test")
-        connect = Client(**stub_creds)
-        with pytest.raises(RetrieverFileError):
-            connect.get_file_info(file_name="foo.mrc", remote_dir="testdir")
-
-    @pytest.mark.parametrize("port, uid_gid", [(21, None), (22, 0)])
-    def test_Client_list_file_info(self, mock_Client, stub_creds, port, uid_gid):
-        (
-            stub_creds["port"],
-            stub_creds["name"],
-        ) = (port, "test")
-        connect = Client(**stub_creds)
+    @pytest.mark.parametrize("port", [21, 22])
+    def test_Client_list_file_info(self, mock_Client, stub_Client_creds, port):
+        stub_Client_creds["port"] = port
+        connect = Client(**stub_Client_creds)
         all_files = connect.list_file_info(remote_dir="testdir")
         recent_files_int = connect.list_file_info(
             remote_dir="testdir",
@@ -224,18 +171,15 @@ class TestMockClient:
         assert all_files[0].file_mtime == 1704070800
         assert all_files[0].file_size == 140401
         assert all_files[0].file_mode == 33188
-        assert all_files[0].file_uid == uid_gid
-        assert all_files[0].file_gid == uid_gid
-        assert all_files[0].file_atime is None
         assert recent_files_int == []
         assert recent_files_dt == []
 
-    def test_Client_list_sftp_file_not_found(self, mock_file_error, stub_creds):
-        (
-            stub_creds["port"],
-            stub_creds["name"],
-        ) = (22, "test")
-        connect = Client(**stub_creds)
+    @pytest.mark.parametrize("port", [21, 22])
+    def test_Client_list_file_info_error(
+        self, mock_file_error, stub_Client_creds, port
+    ):
+        stub_Client_creds["port"] = port
+        connect = Client(**stub_Client_creds)
         with pytest.raises(RetrieverFileError):
             connect.list_file_info(remote_dir="testdir")
 
@@ -244,13 +188,10 @@ class TestMockClient:
         [(21, True), (21, False), (22, True), (22, False)],
     )
     def test_Client_put_file(
-        self, mock_Client, mock_file_info, stub_creds, port, check
+        self, mock_Client, mock_file_info, stub_Client_creds, port, check
     ):
-        (
-            stub_creds["port"],
-            stub_creds["name"],
-        ) = (port, "test")
-        connect = Client(**stub_creds)
+        stub_Client_creds["port"] = port
+        connect = Client(**stub_Client_creds)
         file = mock_file_info
         file.file_stream = io.BytesIO(b"0")
         local_file = connect.put_file(file=file, dir="bar", remote=False, check=check)
@@ -258,58 +199,41 @@ class TestMockClient:
         assert remote_file.file_mtime == 1704070800
         assert local_file.file_mtime == 1704070800
 
-    def test_Client_ftp_put_file_error_perm(
-        self, mock_file_error, mock_file_info, stub_creds
+    @pytest.mark.parametrize("port", [21, 22])
+    def test_Client_put_file_remote_error(
+        self, mock_file_error, mock_file_info, stub_Client_creds, port
     ):
-        (
-            stub_creds["port"],
-            stub_creds["name"],
-        ) = (21, "test")
-        connect = Client(**stub_creds)
+        stub_Client_creds["port"] = port
+        connect = Client(**stub_Client_creds)
         mock_file_info.file_stream = io.BytesIO(b"0")
         with pytest.raises(RetrieverFileError):
             connect.put_file(file=mock_file_info, dir="bar", remote=True, check=False)
 
-    def test_Client_ftp_put_file_OSError(
-        self, mock_file_error, mock_file_info, stub_creds
+    @pytest.mark.parametrize("port", [21, 22])
+    def test_Client_put_file_local_error(
+        self, mock_file_error, mock_file_info, stub_Client_creds, port
     ):
-        (
-            stub_creds["port"],
-            stub_creds["name"],
-        ) = (21, "test")
-        connect = Client(**stub_creds)
+        stub_Client_creds["port"] = port
+        connect = Client(**stub_Client_creds)
         mock_file_info.file_stream = io.BytesIO(b"0")
         with pytest.raises(RetrieverFileError):
             connect.put_file(file=mock_file_info, dir="bar", remote=False, check=False)
-
-    @pytest.mark.parametrize(
-        "remote",
-        [True, False],
-    )
-    def test_Client_sftp_put_file_OSError(
-        self, mock_file_error, mock_file_info, stub_creds, remote
-    ):
-        (
-            stub_creds["port"],
-            stub_creds["name"],
-        ) = (22, "test")
-        connect = Client(**stub_creds)
-        mock_file_info.file_stream = io.BytesIO(b"0")
-        with pytest.raises(RetrieverFileError):
-            connect.put_file(file=mock_file_info, dir="bar", remote=remote, check=False)
 
     @pytest.mark.parametrize(
         "port, remote",
         [(21, True), (21, False), (22, True), (22, False)],
     )
     def test_Client_put_file_exists(
-        self, mock_Client_file_exists, mock_file_info, stub_creds, caplog, port, remote
+        self,
+        mock_Client_file_exists,
+        mock_file_info,
+        stub_Client_creds,
+        caplog,
+        port,
+        remote,
     ):
-        (
-            stub_creds["port"],
-            stub_creds["name"],
-        ) = (port, "test")
-        connect = Client(**stub_creds)
+        stub_Client_creds["port"] = port
+        connect = Client(**stub_Client_creds)
         mock_file_info.file_stream = io.BytesIO(b"0")
         connect.put_file(file=mock_file_info, dir="bar", remote=remote, check=True)
         assert (


### PR DESCRIPTION
Fixed:
 + alphabetized methods within `_ftpClient` and `_sftpClient` classes

Removed:
 + unused fixtures from `conftest`
 + deduplicated and simplified mocks within `conftest`