### PR TITLE
Added directory comparison and sftp host key handling

### DIFF
--- a/file_retriever/_clients.py
+++ b/file_retriever/_clients.py
@@ -347,7 +347,8 @@ class _sftpClient(_BaseClient):
         """
         try:
             ssh = paramiko.SSHClient()
-            ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+            ssh.load_host_keys(filename=os.path.expanduser("~/.ssh/known_hosts"))
+            ssh.set_missing_host_key_policy(paramiko.WarningPolicy())
             ssh.connect(
                 hostname=host,
                 port=port,

--- a/file_retriever/_clients.py
+++ b/file_retriever/_clients.py
@@ -331,11 +331,20 @@ class _sftpClient(_BaseClient):
                 username=username, password=password, host=host, port=int(port)
             )
 
+    def __configure_host_keys(self, host_key_file: str) -> None:
+        """Add host keys to file. To be used when setting up client for first time"""
+        ssh = paramiko.SSHClient()
+        ssh.load_host_keys(filename=host_key_file)
+        ssh.save_host_keys(filename=os.path.expanduser("~/.ssh/vendor_hosts"))
+
     def _connect_to_server(
         self, username: str, password: str, host: str, port: int
     ) -> paramiko.SFTPClient:
         """
-        Opens connection to server via SFTP.
+        Opens connection to server via SFTP. Loads host keys from file. If using
+        client for the first time, user will be prompted to enter path to file of
+        known_hosts. Host keys will then be saved to a `vendor_hosts` file in the
+        user's `.ssh` directory.
 
         Returns:
             `paramiko.SFTPClient` object
@@ -345,9 +354,15 @@ class _sftpClient(_BaseClient):
             paramiko.AuthenticationException: if unable to authenticate with server
 
         """
+        if not os.path.isfile(os.path.expanduser("~/.ssh/vendor_hosts")):
+            logger.debug("Host keys file not found. Creating new file.")
+            file = input("Enter path to host keys file: ")
+            self.__configure_host_keys(host_key_file=file)
         try:
             ssh = paramiko.SSHClient()
-            ssh.load_host_keys(filename=os.path.expanduser("~/.ssh/known_hosts"))
+            ssh.load_system_host_keys(
+                filename=os.path.expanduser("~/.ssh/vendor_hosts")
+            )
             ssh.set_missing_host_key_policy(paramiko.WarningPolicy())
             ssh.connect(
                 hostname=host,

--- a/file_retriever/_clients.py
+++ b/file_retriever/_clients.py
@@ -332,7 +332,15 @@ class _sftpClient(_BaseClient):
             )
 
     def __configure_host_keys(self, host_key_file: str) -> None:
-        """Add host keys to file. To be used when setting up client for first time"""
+        """
+        Load host keys from file and save to a file to be used by this program.
+        User will be prompted to enter path to file of known_hosts. Host keys
+        will then be saved to a `vendor_hosts` file in the user's `.ssh` directory.
+
+        Args:
+            host_key_file: path to file containing host keys
+
+        """
         ssh = paramiko.SSHClient()
         ssh.load_host_keys(filename=host_key_file)
         ssh.save_host_keys(filename=os.path.expanduser("~/.ssh/vendor_hosts"))
@@ -341,10 +349,7 @@ class _sftpClient(_BaseClient):
         self, username: str, password: str, host: str, port: int
     ) -> paramiko.SFTPClient:
         """
-        Opens connection to server via SFTP. Loads host keys from file. If using
-        client for the first time, user will be prompted to enter path to file of
-        known_hosts. Host keys will then be saved to a `vendor_hosts` file in the
-        user's `.ssh` directory.
+        Opens connection to server via SFTP.
 
         Returns:
             `paramiko.SFTPClient` object

--- a/file_retriever/connect.py
+++ b/file_retriever/connect.py
@@ -150,10 +150,17 @@ class Client:
             remote: whether to check for files on server (True) or locally (False)
         """
         missing_files = []
+        logger.debug(
+            f"({self.name}) Checking list of {(len(files))} files against `{dir}`"
+        )
         for file in files:
             exists = self.check_file(file=file, dir=dir, remote=remote)
             if not exists:
                 missing_files.append(file)
+        logger.debug(
+            f"({self.name}) {(len(missing_files))} of {len(files)} files "
+            f"missing from `{dir}`"
+        )
         return missing_files
 
     def get_file(self, file: FileInfo, remote_dir: str) -> File:

--- a/file_retriever/connect.py
+++ b/file_retriever/connect.py
@@ -105,7 +105,7 @@ class Client:
         """Checks if connection to server is active."""
         return self.session.is_active()
 
-    def file_exists(self, file: FileInfo, dir: str, remote: bool) -> bool:
+    def check_file(self, file: FileInfo, dir: str, remote: bool) -> bool:
         """
         Check if file (represented as `FileInfo` object) exists in `dir`.
         If `remote` is the directory will be checked on the server connected
@@ -134,6 +134,27 @@ class Client:
                 return False
         else:
             return os.path.exists(f"{dir}/{file.file_name}")
+
+    def check_file_list(
+        self, files: List[FileInfo], dir: str, remote: bool
+    ) -> List[FileInfo]:
+        """
+        Check if a list of files (represented as `FileInfo` objects) exists in `dir`.
+        If `remote` is True then the directory will be checked on the server connected
+        to via self.session, otherwise the local directory will be checked. Returns
+        list containing only those files that do not exist in `dir`.
+
+        Args:
+            files: list of files to check for as `FileInfo` objects
+            dir: directory to check for files
+            remote: whether to check for files on server (True) or locally (False)
+        """
+        missing_files = []
+        for file in files:
+            exists = self.check_file(file=file, dir=dir, remote=remote)
+            if not exists:
+                missing_files.append(file)
+        return missing_files
 
     def get_file(self, file: FileInfo, remote_dir: str) -> File:
         """
@@ -253,7 +274,7 @@ class Client:
         """
         if check:
             logger.debug(f"({self.name}) Checking for file in `{dir}` before writing")
-        if check and self.file_exists(file=file, dir=dir, remote=remote) is True:
+        if check and self.check_file(file=file, dir=dir, remote=remote) is True:
             logger.debug(
                 f"({self.name}) Skipping {file.file_name}. File already "
                 f"exists in `{dir}`."

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -151,7 +151,7 @@ def mock_Client(monkeypatch, mock_login):
     def mock_file_exists(*args, **kwargs):
         return False
 
-    monkeypatch.setattr(Client, "file_exists", mock_file_exists)
+    monkeypatch.setattr(Client, "check_file", mock_file_exists)
     monkeypatch.setattr(os.path, "exists", mock_file_exists)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -155,8 +155,11 @@ def mock_sftp_no_host_keys(monkeypatch, mock_open_file):
     def mock_connect(*args, **kwargs):
         pass
 
+    def mock_input(*args, **kwargs):
+        return "testdir"
+
     monkeypatch.setattr(os.path, "isfile", mock_isfile)
-    monkeypatch.setattr("builtins.input", lambda x: "testdir")
+    monkeypatch.setattr("builtins.input", mock_input)
     monkeypatch.setattr(paramiko.SSHClient, "load_host_keys", mock_connect)
     monkeypatch.setattr(paramiko.SSHClient, "save_host_keys", mock_connect)
     monkeypatch.setattr(paramiko.SSHClient, "load_system_host_keys", mock_connect)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,9 +141,27 @@ def mock_login(monkeypatch, mock_open_file):
 
     monkeypatch.setattr(os, "stat", mock_stat)
     monkeypatch.setattr(paramiko.SSHClient, "connect", mock_connect)
+    monkeypatch.setattr(paramiko.SSHClient, "load_system_host_keys", mock_connect)
     monkeypatch.setattr(paramiko.SSHClient, "open_sftp", MockSFTPClient)
     monkeypatch.setattr(datetime, "datetime", FakeUtcNow)
     monkeypatch.setattr(ftplib, "FTP", MockFTP)
+
+
+@pytest.fixture
+def mock_sftp_no_host_keys(monkeypatch, mock_open_file):
+    def mock_isfile(*args, **kwargs):
+        return False
+
+    def mock_connect(*args, **kwargs):
+        pass
+
+    monkeypatch.setattr(os.path, "isfile", mock_isfile)
+    monkeypatch.setattr("builtins.input", lambda x: "testdir")
+    monkeypatch.setattr(paramiko.SSHClient, "load_host_keys", mock_connect)
+    monkeypatch.setattr(paramiko.SSHClient, "save_host_keys", mock_connect)
+    monkeypatch.setattr(paramiko.SSHClient, "load_system_host_keys", mock_connect)
+    monkeypatch.setattr(paramiko.SSHClient, "connect", mock_connect)
+    monkeypatch.setattr(paramiko.SSHClient, "open_sftp", MockSFTPClient)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -133,13 +133,17 @@ class MockSFTPClient:
 
 @pytest.fixture
 def mock_login(monkeypatch, mock_open_file):
-    def mock_connect(*args, **kwargs):
-        pass
-
     def mock_stat(*args, **kwargs):
         return MockStatData()
 
+    def mock_isfile(*args, **kwargs):
+        return True
+
+    def mock_connect(*args, **kwargs):
+        pass
+
     monkeypatch.setattr(os, "stat", mock_stat)
+    monkeypatch.setattr(os.path, "isfile", mock_isfile)
     monkeypatch.setattr(paramiko.SSHClient, "connect", mock_connect)
     monkeypatch.setattr(paramiko.SSHClient, "load_system_host_keys", mock_connect)
     monkeypatch.setattr(paramiko.SSHClient, "open_sftp", MockSFTPClient)

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -188,11 +188,10 @@ class TestMock_sftpClient:
         sftp = _sftpClient(**stub_creds)
         assert sftp.connection is not None
 
-    def test_sftpClient_no_host_keys(self, mock_sftp_no_host_keys, stub_creds, caplog):
+    def test_sftpClient_no_host_keys(self, mock_sftp_no_host_keys, stub_creds):
         stub_creds["port"] = "22"
         sftp = _sftpClient(**stub_creds)
         assert sftp.connection is not None
-        assert "Host keys file not found" in caplog.text
 
     def test_sftpClient_no_creds(self, mock_login):
         creds = {}

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -188,6 +188,12 @@ class TestMock_sftpClient:
         sftp = _sftpClient(**stub_creds)
         assert sftp.connection is not None
 
+    def test_sftpClient_no_host_keys(self, mock_sftp_no_host_keys, stub_creds, caplog):
+        stub_creds["port"] = "22"
+        sftp = _sftpClient(**stub_creds)
+        assert sftp.connection is not None
+        assert "Host keys file not found" in caplog.text
+
     def test_sftpClient_no_creds(self, mock_login):
         creds = {}
         with pytest.raises(TypeError):

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -85,28 +85,55 @@ class TestMockClient:
         "port",
         [21, 22],
     )
-    def test_Client_file_exists_true(
+    def test_Client_check_file_true(
         self, mock_Client_file_exists, stub_Client_creds, port, mock_file_info
     ):
         stub_Client_creds["port"] = port
         connect = Client(**stub_Client_creds)
-        local_file_exists = connect.file_exists(
-            file=mock_file_info, dir="bar", remote=False
-        )
-        remote_file_exists = connect.file_exists(
-            file=mock_file_info, dir="bar", remote=True
-        )
-        assert local_file_exists is True
-        assert remote_file_exists is True
+        local_file = connect.check_file(file=mock_file_info, dir="bar", remote=False)
+        remote_file = connect.check_file(file=mock_file_info, dir="bar", remote=True)
+        assert local_file is True
+        assert remote_file is True
 
     @pytest.mark.parametrize("port", [21, 22])
-    def test_Client_file_exists_false(
+    def test_Client_check_file_false(
         self, mock_file_error, stub_Client_creds, mock_file_info, port
     ):
         stub_Client_creds["port"] = port
         connect = Client(**stub_Client_creds)
-        file_exists = connect.file_exists(file=mock_file_info, dir="bar", remote=True)
+        file_exists = connect.check_file(file=mock_file_info, dir="bar", remote=True)
         assert file_exists is False
+
+    @pytest.mark.parametrize(
+        "port",
+        [21, 22],
+    )
+    def test_Client_check_file_list_true(
+        self, mock_Client_file_exists, stub_Client_creds, port, mock_file_info
+    ):
+        stub_Client_creds["port"] = port
+        connect = Client(**stub_Client_creds)
+        mock_file_list = [mock_file_info]
+        local_files = connect.check_file_list(
+            files=mock_file_list, dir="bar", remote=False
+        )
+        remote_files = connect.check_file_list(
+            files=mock_file_list, dir="bar", remote=True
+        )
+        assert len(local_files) == 0
+        assert len(remote_files) == 0
+
+    @pytest.mark.parametrize("port", [21, 22])
+    def test_Client_check_file_list_false(
+        self, mock_file_error, stub_Client_creds, mock_file_info, port
+    ):
+        stub_Client_creds["port"] = port
+        connect = Client(**stub_Client_creds)
+        mock_file_list = [mock_file_info]
+        missing_files = connect.check_file_list(
+            files=mock_file_list, dir="bar", remote=True
+        )
+        assert len(missing_files) == 1
 
     @pytest.mark.parametrize(
         "port",


### PR DESCRIPTION
Added:
 + `__configure_host_keys` private method in `_sftpClient` in order to load host keys from a file when using application for the first time
 + `check_file_list` method in `Client` class in order to check for the presence of an entire list of files in a directory rather than checking one-by-one. method returns subset of list that is not present in the directory

Changed:
 + missing host key policy for `_sftpClient` is now `paramiko.WarningPolicy()`
 + `file_exists` method within `Client` class renamed to `check_file`