### PR TITLE
Updated logging and fixes for Baker & Taylor

### DIFF
--- a/file_retriever/_clients.py
+++ b/file_retriever/_clients.py
@@ -202,6 +202,7 @@ class _ftpClient(_BaseClient):
             ftplib.error_perm:
                 if unable to retrieve file data due to permissions error
         """
+        current_dir = self.connection.pwd()
         try:
             self._check_dir(dir)
 
@@ -218,6 +219,7 @@ class _ftpClient(_BaseClient):
             if size is None or time is None:
                 logger.error(f"Unable to retrieve file data for {file_name}.")
                 raise RetrieverFileError
+            self._check_dir(current_dir)
             return FileInfo(
                 file_name=file_name,
                 file_size=size,

--- a/file_retriever/_clients.py
+++ b/file_retriever/_clients.py
@@ -139,13 +139,13 @@ class _ftpClient(_BaseClient):
         else:
             pass
 
-    def _is_file(self, dir: str, file_name: str) -> str:
+    def _is_file(self, dir: str, file_name: str) -> bool:
         """Checks if object is a file or directory."""
         try:
             self.connection.voidcmd(f"CWD {dir}/{file_name}")
-            return "directory"
+            return False
         except ftplib.error_perm:
-            return "file"
+            return True
 
     def close(self) -> None:
         """Closes connection to server."""
@@ -265,8 +265,8 @@ class _ftpClient(_BaseClient):
             file_names = self.connection.nlst(dir)
             for name in file_names:
                 file_base_name = os.path.basename(name)
-                obj_type = self._is_file(dir, file_base_name)
-                if obj_type == "file":
+                file_obj = self._is_file(dir, file_base_name)
+                if file_obj is True:
                     file_info = self.get_file_data(file_name=file_base_name, dir=dir)
                     files.append(file_info)
                 self._check_dir(current_dir)
@@ -437,6 +437,14 @@ class _sftpClient(_BaseClient):
             self.connection.chdir(dir)
         else:
             pass
+
+    def _is_file(self, dir: str, file_name: str) -> bool:
+        """Checks if object is a file or directory."""
+        try:
+            self.connection.chdir(f"CWD {dir}/{file_name}")
+            return False
+        except OSError:
+            return True
 
     def close(self):
         """Closes connection to server."""

--- a/file_retriever/_clients.py
+++ b/file_retriever/_clients.py
@@ -176,14 +176,16 @@ class _ftpClient(_BaseClient):
             ftplib.error_perm: if unable to retrieve file from server
 
         """
+        current_dir = self.connection.pwd()
         try:
             self._check_dir(dir)
             fh = io.BytesIO()
             self.connection.retrbinary(f"RETR {file.file_name}", fh.write)
             fetched_file = File.from_fileinfo(file=file, file_stream=fh)
+            self._check_dir(current_dir)
             return fetched_file
         except ftplib.error_perm as e:
-            logger.error(f"Unable to retrieve {file} from {dir}: {e}")
+            logger.error(f"Unable to retrieve {file.file_name} from {dir}: {e}")
             raise RetrieverFileError
 
     def get_file_data(self, file_name: str, dir: str) -> FileInfo:

--- a/file_retriever/_clients.py
+++ b/file_retriever/_clients.py
@@ -230,8 +230,7 @@ class _ftpClient(_BaseClient):
                 file_mtime=time[4:],
                 file_mode=permissions,
             )
-        except ftplib.error_perm as e:
-            logger.error(f"Unable to retrieve file data for {file_name}: {e}")
+        except ftplib.error_perm:
             raise RetrieverFileError
 
     def is_active(self) -> bool:
@@ -509,8 +508,7 @@ class _sftpClient(_BaseClient):
             return FileInfo.from_stat_data(
                 data=self.connection.stat(file_name), file_name=file_name
             )
-        except OSError as e:
-            logger.error(f"Unable to retrieve file data for {file_name}: {e}")
+        except OSError:
             raise RetrieverFileError
 
     def is_active(self) -> bool:

--- a/file_retriever/_clients.py
+++ b/file_retriever/_clients.py
@@ -142,6 +142,8 @@ class _ftpClient(_BaseClient):
     def _is_file(self, dir: str, file_name: str) -> bool:
         """Checks if object is a file or directory."""
         current_dir = self.connection.pwd()
+        if dir == "":
+            dir = current_dir
         try:
             self.connection.voidcmd(f"CWD {dir}/{file_name}")
             self._check_dir(current_dir)

--- a/file_retriever/_clients.py
+++ b/file_retriever/_clients.py
@@ -141,8 +141,10 @@ class _ftpClient(_BaseClient):
 
     def _is_file(self, dir: str, file_name: str) -> bool:
         """Checks if object is a file or directory."""
+        current_dir = self.connection.pwd()
         try:
             self.connection.voidcmd(f"CWD {dir}/{file_name}")
+            self._check_dir(current_dir)
             return False
         except ftplib.error_perm:
             return True

--- a/file_retriever/_clients.py
+++ b/file_retriever/_clients.py
@@ -11,6 +11,7 @@ import io
 import logging
 import os
 import paramiko
+import stat
 from typing import Union
 from file_retriever.file import FileInfo, File
 from file_retriever.errors import (
@@ -450,11 +451,11 @@ class _sftpClient(_BaseClient):
 
     def _is_file(self, dir: str, file_name: str) -> bool:
         """Checks if object is a file or directory."""
-        try:
-            self.connection.chdir(f"CWD {dir}/{file_name}")
-            return False
-        except OSError:
+        file_data = self.connection.lstat(f"{dir}/{file_name}")
+        if file_data.st_mode is not None and stat.filemode(file_data.st_mode)[0] == "-":
             return True
+        else:
+            return False
 
     def close(self):
         """Closes connection to server."""

--- a/file_retriever/_clients.py
+++ b/file_retriever/_clients.py
@@ -228,7 +228,8 @@ class _ftpClient(_BaseClient):
                 file_mtime=time[4:],
                 file_mode=permissions,
             )
-        except ftplib.error_perm:
+        except ftplib.error_perm as e:
+            logger.error(f"Unable to retrieve file data for {file_name}: {e}")
             raise RetrieverFileError
 
     def is_active(self) -> bool:
@@ -274,7 +275,8 @@ class _ftpClient(_BaseClient):
                     file_info = self.get_file_data(file_name=file_base_name, dir=dir)
                     files.append(file_info)
                 self._check_dir(current_dir)
-        except ftplib.error_perm:
+        except ftplib.error_perm as e:
+            logger.error(f"Unable to retrieve file list from {dir}: {e}")
             raise RetrieverFileError
         return files
 
@@ -297,7 +299,8 @@ class _ftpClient(_BaseClient):
         try:
             files = self.connection.nlst(dir)
             return [os.path.basename(i) for i in files]
-        except ftplib.error_perm:
+        except ftplib.error_perm as e:
+            logger.error(f"Unable to retrieve file list from {dir}: {e}")
             raise RetrieverFileError
 
     def write_file(self, file: File, dir: str, remote: bool) -> FileInfo:
@@ -504,7 +507,8 @@ class _sftpClient(_BaseClient):
             return FileInfo.from_stat_data(
                 data=self.connection.stat(file_name), file_name=file_name
             )
-        except OSError:
+        except OSError as e:
+            logger.error(f"Unable to retrieve file data for {file_name}: {e}")
             raise RetrieverFileError
 
     def is_active(self) -> bool:
@@ -538,7 +542,7 @@ class _sftpClient(_BaseClient):
             file_metadata = self.connection.listdir_attr(dir)
             return [FileInfo.from_stat_data(data=i) for i in file_metadata]
         except OSError as e:
-            logger.error(f"Unable to retrieve file data for {dir}: {e}")
+            logger.error(f"Unable to retrieve file list from {dir}: {e}")
             raise RetrieverFileError
 
     def list_file_names(self, dir: str) -> list[str]:
@@ -558,7 +562,7 @@ class _sftpClient(_BaseClient):
         try:
             return self.connection.listdir(dir)
         except OSError as e:
-            logger.error(f"Unable to retrieve file data for {dir}: {e}")
+            logger.error(f"Unable to retrieve file list from {dir}: {e}")
             raise RetrieverFileError
 
     def write_file(self, file: File, dir: str, remote: bool) -> FileInfo:

--- a/file_retriever/_clients.py
+++ b/file_retriever/_clients.py
@@ -134,7 +134,7 @@ class _ftpClient(_BaseClient):
 
     def _check_dir(self, dir: str) -> None:
         """Changes directory to `dir` if not already in `dir`."""
-        if self.connection.pwd().lstrip("/") != dir.lstrip("/"):
+        if self.connection.pwd().endswith(dir) is False:
             self.connection.cwd(dir)
         else:
             pass

--- a/file_retriever/_clients.py
+++ b/file_retriever/_clients.py
@@ -291,7 +291,8 @@ class _ftpClient(_BaseClient):
 
         """
         try:
-            return self.connection.nlst(dir)
+            files = self.connection.nlst(dir)
+            return [os.path.basename(i) for i in files]
         except ftplib.error_perm:
             raise RetrieverFileError
 

--- a/file_retriever/connect.py
+++ b/file_retriever/connect.py
@@ -161,6 +161,19 @@ class Client:
             )
             raise e
 
+    def is_file(self, file_name: str, remote_dir: str) -> bool:
+        """
+        Checks if file exists in directory on server.
+
+        Args:
+            file_name: name of file to check for
+            remote_dir: directory on server to interact with
+
+        Returns:
+            bool indicating if `file_name` exists in `remote_dir`
+        """
+        return self.session._is_file(file_name=file_name, dir=remote_dir)
+
     def list_file_info(self, remote_dir: str) -> List[FileInfo]:
         """
         Lists metadata for each file in a directory on server.

--- a/file_retriever/file.py
+++ b/file_retriever/file.py
@@ -194,7 +194,7 @@ class File(FileInfo):
         self,
         file_name: str,
         file_mtime: Union[float, str],
-        file_mode: Union[str, int],
+        file_mode: Union[str, int, None],
         file_size: int,
         file_stream: io.BytesIO,
         file_uid: Optional[int] = None,

--- a/file_retriever/file.py
+++ b/file_retriever/file.py
@@ -14,7 +14,7 @@ class FileInfo:
         self,
         file_name: str,
         file_mtime: Union[float, int, str],
-        file_mode: Union[str, int],
+        file_mode: Union[str, int, None],
         file_size: int,
         file_uid: Optional[int] = None,
         file_gid: Optional[int] = None,
@@ -52,6 +52,8 @@ class FileInfo:
 
         if isinstance(file_mode, str):
             self.file_mode = self.__parse_permissions(file_mode)
+        elif file_mode is None:
+            self.file_mode = 0
         else:
             self.file_mode = int(file_mode)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import datetime
 import ftplib
 import os
 import paramiko
+import stat
 from typing import Dict, List, Optional
 import yaml
 import pytest
@@ -126,6 +127,9 @@ class MockSFTPClient:
     def getfo(self, remotepath, fl, *args, **kwargs) -> bytes:
         return fl.write(b"00000")
 
+    def lstat(self, *args, **kwargs) -> paramiko.SFTPAttributes:
+        return MockStatData().sftp_attr()
+
     def listdir(self, *args, **kwargs) -> List[str]:
         return ["foo.mrc"]
 
@@ -231,7 +235,11 @@ def mock_file_error(monkeypatch, mock_login):
     def mock_voidcmd(*args, **kwargs):
         pass
 
+    def mock_stat_filemode(*args, **kwargs):
+        return "drw-r--r--"
+
     monkeypatch.setattr(os, "stat", mock_os_error)
+    monkeypatch.setattr(stat, "filemode", mock_stat_filemode)
     monkeypatch.setattr(MockSFTPClient, "getfo", mock_os_error)
     monkeypatch.setattr(MockSFTPClient, "listdir", mock_os_error)
     monkeypatch.setattr(MockSFTPClient, "listdir_attr", mock_os_error)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -121,6 +121,9 @@ class MockSFTPClient:
     def getfo(self, remotepath, fl, *args, **kwargs) -> bytes:
         return fl.write(b"00000")
 
+    def listdir(self, *args, **kwargs) -> List[str]:
+        return ["foo.mrc"]
+
     def listdir_attr(self, *args, **kwargs) -> List[paramiko.SFTPAttributes]:
         return [MockStatData().sftp_attr()]
 
@@ -222,6 +225,7 @@ def mock_file_error(monkeypatch, mock_login):
 
     monkeypatch.setattr(os, "stat", mock_os_error)
     monkeypatch.setattr(MockSFTPClient, "getfo", mock_os_error)
+    monkeypatch.setattr(MockSFTPClient, "listdir", mock_os_error)
     monkeypatch.setattr(MockSFTPClient, "listdir_attr", mock_os_error)
     monkeypatch.setattr(MockSFTPClient, "putfo", mock_os_error)
     monkeypatch.setattr(MockSFTPClient, "stat", mock_os_error)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,6 +61,9 @@ def mock_open_file(mocker):
 class MockFTP:
     """Mock response from FTP server for a successful login"""
 
+    def __init__(self, *args, **kwargs):
+        self.host = "ftp.testvendor.com"
+
     def close(self, *args, **kwargs) -> None:
         pass
 
@@ -96,6 +99,8 @@ class MockFTP:
     def voidcmd(self, *args, **kwargs) -> str:
         if "MDTM" in args[0]:
             return "213 20240101010000"
+        elif "CWD" in args[0]:
+            raise ftplib.error_perm
         else:
             return "200"
 
@@ -223,6 +228,9 @@ def mock_file_error(monkeypatch, mock_login):
     def mock_ftp_error_perm(*args, **kwargs):
         raise ftplib.error_perm
 
+    def mock_voidcmd(*args, **kwargs):
+        pass
+
     monkeypatch.setattr(os, "stat", mock_os_error)
     monkeypatch.setattr(MockSFTPClient, "getfo", mock_os_error)
     monkeypatch.setattr(MockSFTPClient, "listdir", mock_os_error)
@@ -230,9 +238,10 @@ def mock_file_error(monkeypatch, mock_login):
     monkeypatch.setattr(MockSFTPClient, "putfo", mock_os_error)
     monkeypatch.setattr(MockSFTPClient, "stat", mock_os_error)
     monkeypatch.setattr(MockFTP, "nlst", mock_ftp_error_perm)
+    monkeypatch.setattr(MockFTP, "size", mock_ftp_error_perm)
     monkeypatch.setattr(MockFTP, "retrbinary", mock_ftp_error_perm)
     monkeypatch.setattr(MockFTP, "storbinary", mock_ftp_error_perm)
-    monkeypatch.setattr(MockFTP, "voidcmd", mock_ftp_error_perm)
+    monkeypatch.setattr(MockFTP, "voidcmd", mock_voidcmd)
 
 
 @pytest.fixture

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -21,6 +21,7 @@ def test_BaseClient(mock_file_info):
     assert ftp_bc.fetch_file(file="foo.mrc", dir="bar") is None
     assert ftp_bc.get_file_data(file_name="foo.mrc", dir="bar") is None
     assert ftp_bc.list_file_data(dir="foo") is None
+    assert ftp_bc.list_file_names(dir="foo") is None
     assert ftp_bc.is_active() is None
     assert ftp_bc.write_file(file=mock_file_info, dir="bar", remote=True) is None
 
@@ -125,6 +126,20 @@ class TestMock_ftpClient:
         ftp = _ftpClient(**stub_creds)
         with pytest.raises(RetrieverFileError):
             ftp.list_file_data(dir="testdir")
+
+    def test_ftpClient_list_file_names(self, mock_Client, stub_creds):
+        stub_creds["port"] = "21"
+        ftp = _ftpClient(**stub_creds)
+        files = ftp.list_file_names(dir="testdir")
+        assert all(isinstance(file, str) for file in files)
+        assert len(files) == 1
+        assert files[0] == "foo.mrc"
+
+    def test_ftpClient_list_file_names_error(self, mock_file_error, stub_creds):
+        stub_creds["port"] = "21"
+        ftp = _ftpClient(**stub_creds)
+        with pytest.raises(RetrieverFileError):
+            ftp.list_file_names(dir="testdir")
 
     def test_ftpClient_is_active_true(self, mock_Client, stub_creds):
         stub_creds["port"] = "21"
@@ -286,6 +301,20 @@ class TestMock_sftpClient:
         sftp = _sftpClient(**stub_creds)
         with pytest.raises(RetrieverFileError):
             sftp.list_file_data(dir="testdir")
+
+    def test_sftpClient_list_file_names(self, mock_Client, stub_creds):
+        stub_creds["port"] = "22"
+        ftp = _sftpClient(**stub_creds)
+        files = ftp.list_file_names(dir="testdir")
+        assert all(isinstance(file, str) for file in files)
+        assert len(files) == 1
+        assert files[0] == "foo.mrc"
+
+    def test_sftpClient_list_file_names_error(self, mock_file_error, stub_creds):
+        stub_creds["port"] = "22"
+        sftp = _sftpClient(**stub_creds)
+        with pytest.raises(RetrieverFileError):
+            sftp.list_file_names(dir="testdir")
 
     def test_sftpClient_is_active_true(self, mock_Client, stub_creds):
         stub_creds["port"] = "22"

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -64,20 +64,20 @@ class TestMock_ftpClient:
     def test_ftpClient_is_file(self, mock_Client, stub_creds):
         stub_creds["port"] = "21"
         ftp = _ftpClient(**stub_creds)
-        obj_type = ftp._is_file(dir="foo", file_name="bar.mrc")
-        assert obj_type is True
+        is_file = ftp._is_file(dir="foo", file_name="bar.mrc")
+        assert is_file is True
 
     def test_ftpClient_is_file_directory(self, mock_file_error, stub_creds):
         stub_creds["port"] = "21"
         ftp = _ftpClient(**stub_creds)
-        obj_type = ftp._is_file(dir="foo", file_name="bar")
-        assert obj_type is False
+        is_file = ftp._is_file(dir="foo", file_name="bar")
+        assert is_file is False
 
     def test_ftpClient_is_file_root(self, mock_Client, stub_creds):
         stub_creds["port"] = "21"
         ftp = _ftpClient(**stub_creds)
-        obj_type = ftp._is_file(dir="", file_name="bar.mrc")
-        assert obj_type is True
+        is_file = ftp._is_file(dir="", file_name="bar.mrc")
+        assert is_file is True
 
     def test_ftpClient_is_file_root_directory(self, mock_file_error, stub_creds):
         stub_creds["port"] = "21"
@@ -268,6 +268,30 @@ class TestMock_sftpClient:
         with does_not_raise():
             sftp._check_dir(dir="foo")
 
+    def test_sftpClient_is_file(self, mock_Client, stub_creds):
+        stub_creds["port"] = "22"
+        sftp = _sftpClient(**stub_creds)
+        is_file = sftp._is_file(dir="foo", file_name="bar.mrc")
+        assert is_file is True
+
+    def test_sftpClient_is_file_directory(self, mock_file_error, stub_creds):
+        stub_creds["port"] = "22"
+        sftp = _sftpClient(**stub_creds)
+        is_file = sftp._is_file(dir="foo", file_name="bar")
+        assert is_file is False
+
+    def test_sftpClient_is_file_root(self, mock_Client, stub_creds):
+        stub_creds["port"] = "22"
+        sftp = _sftpClient(**stub_creds)
+        is_file = sftp._is_file(dir="", file_name="bar.mrc")
+        assert is_file is True
+
+    def test_sftpClient_is_file_root_directory(self, mock_file_error, stub_creds):
+        stub_creds["port"] = "22"
+        sftp = _sftpClient(**stub_creds)
+        obj_type = sftp._is_file(dir="", file_name="bar")
+        assert obj_type is False
+
     def test_sftpClient_close(self, mock_Client, stub_creds):
         stub_creds["port"] = "22"
         sftp = _sftpClient(**stub_creds)
@@ -403,18 +427,7 @@ class TestMock_sftpClient:
 
 @pytest.mark.livetest
 class TestLiveClients:
-    def test_ftpClient_live_test_baker_taylor(self, live_creds):
-        remote_dir = os.environ["BAKERTAYLOR_NYPL_SRC"]
-        live_ftp = _ftpClient(
-            username=os.environ["BAKERTAYLOR_NYPL_USER"],
-            password=os.environ["BAKERTAYLOR_NYPL_PASSWORD"],
-            host=os.environ["BAKERTAYLOR_NYPL_HOST"],
-            port=os.environ["BAKERTAYLOR_NYPL_PORT"],
-        )
-        file_list = live_ftp.list_file_data(dir=remote_dir)
-        assert len(file_list) > 1
-
-    def test_ftpClient_live_test_leila(self, live_creds):
+    def test_ftpClient_live_test(self, live_creds):
         remote_dir = os.environ["LEILA_SRC"]
         live_ftp = _ftpClient(
             username=os.environ["LEILA_USER"],

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -61,6 +61,18 @@ class TestMock_ftpClient:
         with does_not_raise():
             ftp._check_dir(dir="/")
 
+    def test_ftpClient_is_file(self, mock_Client, stub_creds):
+        stub_creds["port"] = "21"
+        ftp = _ftpClient(**stub_creds)
+        obj_type = ftp._is_file(dir="foo", file_name="bar.mrc")
+        assert obj_type == "file"
+
+    def test_ftpClient_is_file_directory(self, mock_file_error, stub_creds):
+        stub_creds["port"] = "21"
+        ftp = _ftpClient(**stub_creds)
+        obj_type = ftp._is_file(dir="foo", file_name="bar")
+        assert obj_type == "directory"
+
     def test_ftpClient_close(self, mock_Client, stub_creds):
         stub_creds["port"] = "21"
         ftp = _ftpClient(**stub_creds)
@@ -379,7 +391,23 @@ class TestMock_sftpClient:
 
 @pytest.mark.livetest
 class TestLiveClients:
-    def test_ftpClient_live_test(self, live_creds):
+    def test_ftpClient_live_test_baker_taylor(self, live_creds):
+        remote_dir = os.environ["BAKERTAYLOR_NYPL_SRC"]
+        live_ftp = _ftpClient(
+            username=os.environ["BAKERTAYLOR_NYPL_USER"],
+            password=os.environ["BAKERTAYLOR_NYPL_PASSWORD"],
+            host=os.environ["BAKERTAYLOR_NYPL_HOST"],
+            port=os.environ["BAKERTAYLOR_NYPL_PORT"],
+        )
+        # test_data = live_ftp.connection.sendcmd("PWD")
+        # print(test_data)
+        # print(remote_dir)
+        # test_data_2 = live_ftp.connection.sendcmd(f"CWD {remote_dir}")
+        # print(test_data_2)
+        file_list = live_ftp.list_file_data(dir=remote_dir)
+        assert len(file_list) > 1
+
+    def test_ftpClient_live_test_leila(self, live_creds):
         remote_dir = os.environ["LEILA_SRC"]
         live_ftp = _ftpClient(
             username=os.environ["LEILA_USER"],

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -17,12 +17,13 @@ def test_BaseClient(mock_file_info):
     ftp_bc = _BaseClient(username="foo", password="bar", host="baz", port=21)
     assert ftp_bc.__dict__ == {"connection": None}
     assert ftp_bc._check_dir(dir="foo") is None
+    assert ftp_bc._is_file(dir="foo", file_name="bar") is None
     assert ftp_bc.close() is None
     assert ftp_bc.fetch_file(file="foo.mrc", dir="bar") is None
     assert ftp_bc.get_file_data(file_name="foo.mrc", dir="bar") is None
+    assert ftp_bc.is_active() is None
     assert ftp_bc.list_file_data(dir="foo") is None
     assert ftp_bc.list_file_names(dir="foo") is None
-    assert ftp_bc.is_active() is None
     assert ftp_bc.write_file(file=mock_file_info, dir="bar", remote=True) is None
 
 

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -65,13 +65,13 @@ class TestMock_ftpClient:
         stub_creds["port"] = "21"
         ftp = _ftpClient(**stub_creds)
         obj_type = ftp._is_file(dir="foo", file_name="bar.mrc")
-        assert obj_type == "file"
+        assert obj_type is True
 
     def test_ftpClient_is_file_directory(self, mock_file_error, stub_creds):
         stub_creds["port"] = "21"
         ftp = _ftpClient(**stub_creds)
         obj_type = ftp._is_file(dir="foo", file_name="bar")
-        assert obj_type == "directory"
+        assert obj_type is False
 
     def test_ftpClient_close(self, mock_Client, stub_creds):
         stub_creds["port"] = "21"

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -73,6 +73,18 @@ class TestMock_ftpClient:
         obj_type = ftp._is_file(dir="foo", file_name="bar")
         assert obj_type is False
 
+    def test_ftpClient_is_file_root(self, mock_Client, stub_creds):
+        stub_creds["port"] = "21"
+        ftp = _ftpClient(**stub_creds)
+        obj_type = ftp._is_file(dir="", file_name="bar.mrc")
+        assert obj_type is True
+
+    def test_ftpClient_is_file_root_directory(self, mock_file_error, stub_creds):
+        stub_creds["port"] = "21"
+        ftp = _ftpClient(**stub_creds)
+        obj_type = ftp._is_file(dir="", file_name="bar")
+        assert obj_type is False
+
     def test_ftpClient_close(self, mock_Client, stub_creds):
         stub_creds["port"] = "21"
         ftp = _ftpClient(**stub_creds)
@@ -399,11 +411,6 @@ class TestLiveClients:
             host=os.environ["BAKERTAYLOR_NYPL_HOST"],
             port=os.environ["BAKERTAYLOR_NYPL_PORT"],
         )
-        # test_data = live_ftp.connection.sendcmd("PWD")
-        # print(test_data)
-        # print(remote_dir)
-        # test_data_2 = live_ftp.connection.sendcmd(f"CWD {remote_dir}")
-        # print(test_data_2)
         file_list = live_ftp.list_file_data(dir=remote_dir)
         assert len(file_list) > 1
 

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -211,6 +211,22 @@ class TestMockClient:
         with pytest.raises(RetrieverFileError):
             connect.list_file_info(remote_dir="testdir")
 
+    @pytest.mark.parametrize("port", [21, 22])
+    def test_Client_list_files(self, mock_Client, stub_Client_creds, port):
+        stub_Client_creds["port"] = port
+        connect = Client(**stub_Client_creds)
+        files = connect.list_files(remote_dir="testdir")
+        assert all(isinstance(file, str) for file in files)
+        assert len(files) == 1
+        assert files[0] == "foo.mrc"
+
+    @pytest.mark.parametrize("port", [21, 22])
+    def test_Client_list_files_error(self, mock_file_error, stub_Client_creds, port):
+        stub_Client_creds["port"] = port
+        connect = Client(**stub_Client_creds)
+        with pytest.raises(RetrieverFileError):
+            connect.list_files(remote_dir="testdir")
+
     @pytest.mark.parametrize(
         "port, check",
         [(21, True), (21, False), (22, True), (22, False)],
@@ -266,7 +282,7 @@ class TestMockClient:
         mock_file_info.file_stream = io.BytesIO(b"0")
         connect.put_file(file=mock_file_info, dir="bar", remote=remote, check=True)
         assert (
-            f"Skipping {mock_file_info.file_name}. File already exists in `bar`."
+            f"{mock_file_info.file_name} already exists in `bar`. Skipping write."
             in caplog.text
         )
 

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -1,4 +1,3 @@
-import datetime
 import io
 import logging
 import os
@@ -109,37 +108,6 @@ class TestMockClient:
         "port",
         [21, 22],
     )
-    def test_Client_check_file_list_true(
-        self, mock_Client_file_exists, stub_Client_creds, port, mock_file_info
-    ):
-        stub_Client_creds["port"] = port
-        connect = Client(**stub_Client_creds)
-        mock_file_list = [mock_file_info]
-        local_files = connect.check_file_list(
-            files=mock_file_list, dir="bar", remote=False
-        )
-        remote_files = connect.check_file_list(
-            files=mock_file_list, dir="bar", remote=True
-        )
-        assert len(local_files) == 0
-        assert len(remote_files) == 0
-
-    @pytest.mark.parametrize("port", [21, 22])
-    def test_Client_check_file_list_false(
-        self, mock_file_error, stub_Client_creds, mock_file_info, port
-    ):
-        stub_Client_creds["port"] = port
-        connect = Client(**stub_Client_creds)
-        mock_file_list = [mock_file_info]
-        missing_files = connect.check_file_list(
-            files=mock_file_list, dir="bar", remote=True
-        )
-        assert len(missing_files) == 1
-
-    @pytest.mark.parametrize(
-        "port",
-        [21, 22],
-    )
     def test_Client_get_file(
         self, mock_Client, mock_file_info, stub_Client_creds, port
     ):
@@ -182,25 +150,11 @@ class TestMockClient:
         stub_Client_creds["port"] = port
         connect = Client(**stub_Client_creds)
         all_files = connect.list_file_info(remote_dir="testdir")
-        recent_files_int = connect.list_file_info(
-            remote_dir="testdir",
-            time_delta=5,
-        )
-        recent_files_dt = connect.list_file_info(
-            remote_dir="testdir", time_delta=datetime.timedelta(days=5)
-        )
         assert all(isinstance(file, FileInfo) for file in all_files)
-        assert all(isinstance(file, FileInfo) for file in recent_files_int)
-        assert all(isinstance(file, FileInfo) for file in recent_files_dt)
-        assert len(all_files) == 1
-        assert len(recent_files_int) == 0
-        assert len(recent_files_dt) == 0
         assert all_files[0].file_name == "foo.mrc"
         assert all_files[0].file_mtime == 1704070800
         assert all_files[0].file_size == 140401
         assert all_files[0].file_mode == 33188
-        assert recent_files_int == []
-        assert recent_files_dt == []
 
     @pytest.mark.parametrize("port", [21, 22])
     def test_Client_list_file_info_error(
@@ -282,7 +236,7 @@ class TestMockClient:
         mock_file_info.file_stream = io.BytesIO(b"0")
         connect.put_file(file=mock_file_info, dir="bar", remote=remote, check=True)
         assert (
-            f"{mock_file_info.file_name} already exists in `bar`. Skipping write."
+            f"{mock_file_info.file_name} already exists in `bar`. Skipping copy."
             in caplog.text
         )
 

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -146,6 +146,36 @@ class TestMockClient:
             connect.get_file_info(file_name="foo.mrc", remote_dir="testdir")
 
     @pytest.mark.parametrize("port", [21, 22])
+    def test_Client_is_file(self, mock_Client, stub_Client_creds, port):
+        stub_Client_creds["port"] = port
+        connect = Client(**stub_Client_creds)
+        is_file = connect.is_file(file_name="bar.mrc", remote_dir="foo")
+        assert is_file is True
+
+    @pytest.mark.parametrize("port", [21, 22])
+    def test_Client_is_file_directory(self, mock_file_error, stub_Client_creds, port):
+        stub_Client_creds["port"] = port
+        connect = Client(**stub_Client_creds)
+        is_file = connect.is_file(file_name="bar", remote_dir="foo")
+        assert is_file is False
+
+    @pytest.mark.parametrize("port", [21, 22])
+    def test_Client_is_file_root(self, mock_Client, stub_Client_creds, port):
+        stub_Client_creds["port"] = port
+        connect = Client(**stub_Client_creds)
+        is_file = connect.is_file(file_name="bar.mrc", remote_dir="")
+        assert is_file is True
+
+    @pytest.mark.parametrize("port", [21, 22])
+    def test_Client_is_file_root_directory(
+        self, mock_file_error, stub_Client_creds, port
+    ):
+        stub_Client_creds["port"] = port
+        connect = Client(**stub_Client_creds)
+        is_file = connect.is_file(file_name="bar", remote_dir="")
+        assert is_file is False
+
+    @pytest.mark.parametrize("port", [21, 22])
     def test_Client_list_file_info(self, mock_Client, stub_Client_creds, port):
         stub_Client_creds["port"] = port
         connect = Client(**stub_Client_creds)
@@ -242,30 +272,37 @@ class TestMockClient:
 
 
 @pytest.mark.livetest
-def test_Client_ftp_live_test(live_creds):
-    vendor = "LEILA"
-    live_ftp = Client(
-        name=vendor,
-        username=os.environ[f"{vendor}_USER"],
-        password=os.environ[f"{vendor}_PASSWORD"],
-        host=os.environ[f"{vendor}_HOST"],
-        port=os.environ[f"{vendor}_PORT"],
-    )
-    files = live_ftp.list_file_info(remote_dir=os.environ[f"{vendor}_SRC"])
-    assert len(files) > 1
-    assert "220" in live_ftp.session.connection.getwelcome()
+class TestLiveClient:
+    def test_Client_ftp_live_test(self, live_creds):
+        vendors = ["LEILA", "BAKERTAYLOR_NYPL", "BAKERTAYLOR_BPL", "MIDWEST_NYPL"]
+        for vendor in vendors:
+            live_ftp = Client(
+                name=vendor,
+                username=os.environ[f"{vendor}_USER"],
+                password=os.environ[f"{vendor}_PASSWORD"],
+                host=os.environ[f"{vendor}_HOST"],
+                port=os.environ[f"{vendor}_PORT"],
+            )
+            files = live_ftp.list_file_info(remote_dir=os.environ[f"{vendor}_SRC"])
+            assert len(files) > 1
+            assert "220" in live_ftp.session.connection.getwelcome()
 
-
-@pytest.mark.livetest
-def test_Client_sftp_live_test(live_creds):
-    vendor = "EASTVIEW"
-    live_sftp = Client(
-        name=vendor,
-        username=os.environ[f"{vendor}_USER"],
-        password=os.environ[f"{vendor}_PASSWORD"],
-        host=os.environ[f"{vendor}_HOST"],
-        port=os.environ[f"{vendor}_PORT"],
-    )
-    files = live_sftp.list_file_info(remote_dir=os.environ[f"{vendor}_SRC"])
-    assert len(files) > 1
-    assert live_sftp.session.connection.get_channel().active == 1
+    def test_Client_sftp_eastview_live_test(self, live_creds):
+        vendors = [
+            "EASTVIEW",
+            "AMALIVRE_LPA",
+            "AMALIVRE_SASB",
+            "AMALIVRE_SCHOMBURG",
+            "AMALIVRE_RL",
+        ]
+        for vendor in vendors:
+            live_sftp = Client(
+                name=vendor,
+                username=os.environ[f"{vendor}_USER"],
+                password=os.environ[f"{vendor}_PASSWORD"],
+                host=os.environ[f"{vendor}_HOST"],
+                port=os.environ[f"{vendor}_PORT"],
+            )
+            files = live_sftp.list_file_info(remote_dir=os.environ[f"{vendor}_SRC"])
+            assert len(files) > 1
+            assert live_sftp.session.connection.get_channel().active == 1

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -273,19 +273,31 @@ class TestMockClient:
 
 @pytest.mark.livetest
 class TestLiveClient:
-    def test_Client_ftp_live_test(self, live_creds):
-        vendors = ["LEILA", "BAKERTAYLOR_NYPL", "BAKERTAYLOR_BPL", "MIDWEST_NYPL"]
-        for vendor in vendors:
-            live_ftp = Client(
-                name=vendor,
-                username=os.environ[f"{vendor}_USER"],
-                password=os.environ[f"{vendor}_PASSWORD"],
-                host=os.environ[f"{vendor}_HOST"],
-                port=os.environ[f"{vendor}_PORT"],
-            )
-            files = live_ftp.list_file_info(remote_dir=os.environ[f"{vendor}_SRC"])
-            assert len(files) > 1
-            assert "220" in live_ftp.session.connection.getwelcome()
+    def test_Client_ftp_live_test_leila(self, live_creds):
+        vendor = "LEILA"
+        live_ftp = Client(
+            name=vendor,
+            username=os.environ[f"{vendor}_USER"],
+            password=os.environ[f"{vendor}_PASSWORD"],
+            host=os.environ[f"{vendor}_HOST"],
+            port=os.environ[f"{vendor}_PORT"],
+        )
+        files = live_ftp.list_file_info(remote_dir=os.environ[f"{vendor}_SRC"])
+        assert len(files) > 1
+        assert "220" in live_ftp.session.connection.getwelcome()
+
+    def test_Client_ftp_live_test_bakertaylor(self, live_creds):
+        vendor = "BAKERTAYLOR_BPL"
+        live_ftp = Client(
+            name=vendor,
+            username=os.environ[f"{vendor}_USER"],
+            password=os.environ[f"{vendor}_PASSWORD"],
+            host=os.environ[f"{vendor}_HOST"],
+            port=os.environ[f"{vendor}_PORT"],
+        )
+        files = live_ftp.list_file_info(remote_dir=os.environ[f"{vendor}_SRC"])
+        assert len(files) > 1
+        assert "220" in live_ftp.session.connection.getwelcome()
 
     def test_Client_sftp_eastview_live_test(self, live_creds):
         vendors = [

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -20,6 +20,22 @@ def test_FileInfo():
     assert isinstance(file, FileInfo)
 
 
+def test_FileInfo_baker_taylor():
+    file = FileInfo(
+        file_name="foo.mrc", file_mtime=1704070800, file_mode=None, file_size=1
+    )
+    assert file.file_name == "foo.mrc"
+    assert file.file_mtime == 1704070800
+    assert file.file_mode == 0
+    assert file.file_size == 1
+    assert file.file_gid is None
+    assert file.file_uid is None
+    assert file.file_atime is None
+    assert isinstance(file.file_name, str)
+    assert isinstance(file.file_mtime, int)
+    assert isinstance(file, FileInfo)
+
+
 def test_FileInfo_from_stat_data(mock_sftp_attr):
     foo = FileInfo.from_stat_data(data=mock_sftp_attr)
     bar_attr = mock_sftp_attr


### PR DESCRIPTION
Added
 - `Client.is_file` method (`_ftpClient._is_file` and `_sftpClient._is_file`) to check if an object in a directory is a file or a directory. 
 - `Client.list_file_names` method to speed up comparisons between a directory on an FTP server and another directory

Changed
 - added additional directory checks to `_ftpClient` methods in order to ensure program is operating in the correct directory when retrieving files
 - `_ftpClient.get_file_data` method now accounts for files on Baker & Taylor servers which do not list file permissions in their metadata
 - `FileInfo.file_mode` and `File.file_mode` can now be `None` to account for Baker & Taylor files
 - some logger messages changed to debug rather than info

Removed
 - redundant or unnecessary log messages
 - `Client.check_file_list` method as it is redundant
 - `time_delta` is no longer an arg for `Client.list_file_info`. This parsing can be done outside of this package
 