### PR TITLE
Update to `Client.put_file()` method

### DIFF
--- a/file_retriever/connect.py
+++ b/file_retriever/connect.py
@@ -5,10 +5,11 @@ sftp client to interact with remote storage.
 
 import logging
 import os
-from typing import List, Optional, Union
+from typing import List, Union
+
 from file_retriever._clients import _ftpClient, _sftpClient
-from file_retriever.file import FileInfo, File
 from file_retriever.errors import RetrieverFileError
+from file_retriever.file import File, FileInfo
 
 logger = logging.getLogger(__name__)
 
@@ -159,7 +160,7 @@ class Client:
             return self.session.get_file_data(file_name=file_name, dir=remote_dir)
         except RetrieverFileError as e:
             logger.error(
-                f"({self.name}) Unable to retrieve file data for {file_name}: " f"{e}"
+                f"({self.name}) Unable to retrieve file data for {file_name}: {e}"
             )
             raise e
 
@@ -202,13 +203,7 @@ class Client:
         """
         return self.session.list_file_names(dir=remote_dir)
 
-    def put_file(
-        self,
-        file: File,
-        dir: str,
-        remote: bool,
-        check: bool,
-    ) -> Optional[FileInfo]:
+    def put_file(self, file: File, dir: str, remote: bool) -> FileInfo:
         """
         Writes file to directory.
 
@@ -222,22 +217,9 @@ class Client:
 
                 If True, then file is written to `dir` on server.
                 If False, then file is written to local `dir` directory.
-            check:
-                bool indicating if directory should be checked before writing file.
-
-                If True, then `dir` will be checked for files matching the file_name
-                and file_size of `file` before writing to `dir`. If a match is found
-                then `file` will not be written.
 
         Returns:
             `FileInfo` objects representing written file
         """
-        if check and self.check_file(file=file, dir=dir, remote=remote) is True:
-            logger.debug(
-                f"({self.name}) {file.file_name} already exists in `{dir}`. "
-                f"Skipping copy."
-            )
-            return None
-        else:
-            logger.debug(f"({self.name}) Writing {file.file_name} to `{dir}`")
-            return self.session.write_file(file=file, dir=dir, remote=remote)
+        logger.debug(f"({self.name}) Writing {file.file_name} to `{dir}`")
+        return self.session.write_file(file=file, dir=dir, remote=remote)

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -1,14 +1,15 @@
 import io
-import logging
 import os
+
 import pytest
-from file_retriever.connect import Client
+
 from file_retriever._clients import _ftpClient, _sftpClient
-from file_retriever.file import FileInfo, File
+from file_retriever.connect import Client
 from file_retriever.errors import (
-    RetrieverFileError,
     RetrieverAuthenticationError,
+    RetrieverFileError,
 )
+from file_retriever.file import File, FileInfo
 
 
 class TestMockClient:
@@ -222,8 +223,8 @@ class TestMockClient:
         connect = Client(**stub_Client_creds)
         file = mock_file_info
         file.file_stream = io.BytesIO(b"0")
-        local_file = connect.put_file(file=file, dir="bar", remote=False, check=check)
-        remote_file = connect.put_file(file=file, dir="bar", remote=True, check=check)
+        local_file = connect.put_file(file=file, dir="bar", remote=False)
+        remote_file = connect.put_file(file=file, dir="bar", remote=True)
         assert remote_file.file_mtime == 1704070800
         assert local_file.file_mtime == 1704070800
 
@@ -235,7 +236,7 @@ class TestMockClient:
         connect = Client(**stub_Client_creds)
         mock_file_info.file_stream = io.BytesIO(b"0")
         with pytest.raises(RetrieverFileError):
-            connect.put_file(file=mock_file_info, dir="bar", remote=True, check=False)
+            connect.put_file(file=mock_file_info, dir="bar", remote=True)
 
     @pytest.mark.parametrize("port", [21, 22])
     def test_Client_put_file_local_error(
@@ -245,30 +246,7 @@ class TestMockClient:
         connect = Client(**stub_Client_creds)
         mock_file_info.file_stream = io.BytesIO(b"0")
         with pytest.raises(RetrieverFileError):
-            connect.put_file(file=mock_file_info, dir="bar", remote=False, check=False)
-
-    @pytest.mark.parametrize(
-        "port, remote",
-        [(21, True), (21, False), (22, True), (22, False)],
-    )
-    def test_Client_put_file_exists(
-        self,
-        mock_Client_file_exists,
-        mock_file_info,
-        stub_Client_creds,
-        caplog,
-        port,
-        remote,
-    ):
-        caplog.set_level(logging.DEBUG)
-        stub_Client_creds["port"] = port
-        connect = Client(**stub_Client_creds)
-        mock_file_info.file_stream = io.BytesIO(b"0")
-        connect.put_file(file=mock_file_info, dir="bar", remote=remote, check=True)
-        assert (
-            f"{mock_file_info.file_name} already exists in `bar`. Skipping copy."
-            in caplog.text
-        )
+            connect.put_file(file=mock_file_info, dir="bar", remote=False)
 
 
 @pytest.mark.livetest


### PR DESCRIPTION
Changed:
 - `Client.put_file()` no longer takes `check` boolean as an arg. This was removed in order to simplify the interface and separate concerns
 - `Client.put_file()` now returns a `FileInfo` object rather than an `Optional[FileInfo]` object